### PR TITLE
Rename instances of messageType to messageName for constistancy

### DIFF
--- a/backend/src/main/java/com/sim_backend/websockets/OCPPUnsupportedMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPUnsupportedMessage.java
@@ -5,17 +5,17 @@ public class OCPPUnsupportedMessage extends RuntimeException {
   /** The OCPP message that failed to process. */
   private final String message;
 
-  /** The failed Message Type. */
-  private final String messageType;
+  /** The failed Message Name. */
+  private final String messageName;
 
   /**
    * An Exception thrown when we fail to process an OCPPMessage.
    *
    * @param msg The message that could not be processed.
    */
-  public OCPPUnsupportedMessage(final String msg, final String msgType) {
+  public OCPPUnsupportedMessage(final String msg, final String msgName) {
     this.message = msg;
-    this.messageType = msgType;
+    this.messageName = msgName;
   }
 
   /**
@@ -28,11 +28,11 @@ public class OCPPUnsupportedMessage extends RuntimeException {
   }
 
   /**
-   * Get the message type of message we do not support.
+   * Get the message name of message we do not support.
    *
-   * @return The Failed message type.
+   * @return The Failed message name.
    */
-  public String getMessageType() {
-    return messageType;
+  public String getMessageName() {
+    return messageName;
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -23,7 +23,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
   private static final int MESSAGE_ID_INDEX = 1;
 
   /** The index in the JsonArray for the message type. */
-  private static final int TYPE_INDEX = 2;
+  private static final int NAME_INDEX = 2;
 
   /** The index in the JsonArray for the payload. */
   public static final int PAYLOAD_INDEX = 3;
@@ -72,7 +72,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
 
       int callID = array.get(CALL_ID_INDEX).getAsInt();
       String msgID = array.get(MESSAGE_ID_INDEX).getAsString();
-      String messageType = array.get(TYPE_INDEX).getAsString();
+      String messageName = array.get(NAME_INDEX).getAsString();
       JsonObject data = array.get(PAYLOAD_INDEX).getAsJsonObject();
 
       Reflections reflections = new Reflections(MESSAGE_PACKAGE);
@@ -86,14 +86,14 @@ public class OCPPWebSocketClient extends WebSocketClient {
         OCPPMessageInfo annotation = messageClass.getAnnotation(OCPPMessageInfo.class);
         // Check if it's a has a parent class of OCPPMessage.
         if (OCPPMessage.class.isAssignableFrom(messageClass)
-            && annotation.messageName().equals(messageType)) {
+            && annotation.messageName().equals(messageName)) {
           // Convert the payload String into the found class.
           OCPPMessage message = (OCPPMessage) gson.fromJson(data, messageClass);
           onReceiveMessage.onMessageReceieved(new OnOCPPMessage(message));
           return;
         }
       }
-      throw new OCPPUnsupportedMessage(s, messageType);
+      throw new OCPPUnsupportedMessage(s, messageName);
     }
   }
 

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -162,7 +162,7 @@ public class OCPPWebSocketClientTest {
     OCPPUnsupportedMessage err =
         assertThrows(OCPPUnsupportedMessage.class, () -> client.popAllMessages());
     assert err != null;
-    assert err.getMessageType().equals("AbsoluteTrash");
+    assert err.getMessageName().equals("AbsoluteTrash");
     assert err.getMessage().equals(msgToSend);
   }
 


### PR DESCRIPTION
I just renamed the instances of messageType to messageName. They meant the same thing as instances of type should of always been name. 