### PR TITLE
Create Authorization, BootNotification, HeartBeat responses and requests

### DIFF
--- a/backend/src/main/java/com/sim_backend/websockets/OCPPMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPMessage.java
@@ -35,7 +35,13 @@ public abstract class OCPPMessage {
     array.add(messageInfo.messageCallID());
     array.add(this.messageID);
     array.add(messageInfo.messageName());
-    array.add(GsonUtilities.getGson().toJsonTree(this));
+    // HeartBeat request requires an empty JSON array, has no JSON fields itself
+    if (messageInfo.messageName().equals("HeartBeat")){
+      array.add(new JsonArray());
+    }
+    else {
+      array.add(GsonUtilities.getGson().toJsonTree(this));
+    }
     return array;
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPMessage.java
@@ -1,12 +1,10 @@
 package com.sim_backend.websockets;
 
 import com.google.gson.JsonArray;
-import java.security.SecureRandom;
+import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class OCPPMessage {
-  /** The maximum allowed message ID length. */
-  public static final int MAX_MESSAGE_ID_LENGTH = 20;
 
   /** The call ID for a request. */
   public static final int CALL_ID_REQUEST = 2;
@@ -60,25 +58,13 @@ public abstract class OCPPMessage {
     return tries;
   }
 
-  /** The Characters we are allowed in a Message ID. */
-  private static final String CHARACTERS =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-  /** Our random generator. */
-  private static final SecureRandom RANDOM = new SecureRandom();
-
   /**
-   * Generates a message ID of a given length.
+   * Generates a unique 36 character UUID
    *
    * @return A randomly generated message ID.
    */
   @NotNull
   private static String generateMessageID() {
-    StringBuilder sb = new StringBuilder(OCPPMessage.MAX_MESSAGE_ID_LENGTH);
-    for (int i = 0; i < OCPPMessage.MAX_MESSAGE_ID_LENGTH; i++) {
-      int randomIndex = RANDOM.nextInt(CHARACTERS.length());
-      sb.append(CHARACTERS.charAt(randomIndex));
-    }
-    return sb.toString();
+    return UUID.randomUUID().toString();
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPMessage.java
@@ -35,13 +35,7 @@ public abstract class OCPPMessage {
     array.add(messageInfo.messageCallID());
     array.add(this.messageID);
     array.add(messageInfo.messageName());
-    // HeartBeat request requires an empty JSON array, has no JSON fields itself
-    if (messageInfo.messageName().equals("HeartBeat")){
-      array.add(new JsonArray());
-    }
-    else {
-      array.add(GsonUtilities.getGson().toJsonTree(this));
-    }
+    array.add(GsonUtilities.getGson().toJsonTree(this));
     return array;
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/Authorize.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/Authorize.java
@@ -1,0 +1,40 @@
+package com.sim_backend.websockets.messages;
+
+import com.google.gson.annotations.SerializedName;
+import com.sim_backend.websockets.OCPPMessage;
+import com.sim_backend.websockets.OCPPMessageInfo;
+
+import java.util.UUID;
+
+@OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_REQUEST, messageName = "Authorize")
+public class Authorize extends OCPPMessage {
+
+  @SerializedName("idTag")
+  private String idTag;
+
+  // Constructor
+  public Authorize(String idTag) {
+      this.idTag = idTag;
+  }
+
+  // Constructor
+  public Authorize() {
+    this.idTag = generateIdTag();
+  }
+
+  // Getter and Setter
+  public String getIdTag() {
+      return idTag;
+  }
+
+  public void setIdTag(String idTag) {
+      this.idTag = idTag;
+  }
+
+  public String generateIdTag() {
+    // Generate a UUID
+    String uuid = UUID.randomUUID().toString();
+    // Remove hyphens and truncate to 20 characters
+    return uuid.replace("-", "").substring(0, 20);
+  }
+}

--- a/backend/src/main/java/com/sim_backend/websockets/messages/Authorize.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/Authorize.java
@@ -3,7 +3,6 @@ package com.sim_backend.websockets.messages;
 import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.OCPPMessage;
 import com.sim_backend.websockets.OCPPMessageInfo;
-
 import java.util.UUID;
 
 @OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_REQUEST, messageName = "Authorize")
@@ -14,21 +13,23 @@ public class Authorize extends OCPPMessage {
 
   // Constructor
   public Authorize(String idTag) {
-      this.idTag = idTag;
+    super();
+    this.idTag = idTag;
   }
 
   // Constructor
   public Authorize() {
+    super();
     this.idTag = generateIdTag();
   }
 
   // Getter and Setter
   public String getIdTag() {
-      return idTag;
+    return idTag;
   }
 
   public void setIdTag(String idTag) {
-      this.idTag = idTag;
+    this.idTag = idTag;
   }
 
   public String generateIdTag() {

--- a/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
@@ -7,21 +7,22 @@ import com.sim_backend.websockets.OCPPMessageInfo;
 @OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_RESPONSE, messageName = "AuthorizeResponse")
 public class AuthorizeResponse extends OCPPMessage {
 
-    @SerializedName("status")
-    private String status;
+  @SerializedName("status")
+  private String status;
 
-    // Constructor
-    public AuthorizeResponse(String status) {
-        this.status = status;
-    }
+  // Constructor
+  public AuthorizeResponse(String status) {
+    super();
+    this.status = status;
+  }
 
-    // Getter
-    public String getStatus() {
-        return status;
-    }
+  // Getter
+  public String getStatus() {
+    return status;
+  }
 
-    // Setter
-    public void setStatus(String status) {
-        this.status = status;
-    }
+  // Setter
+  public void setStatus(String status) {
+    this.status = status;
+  }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
@@ -1,0 +1,27 @@
+package com.sim_backend.websockets.messages;
+
+import com.google.gson.annotations.SerializedName;
+import com.sim_backend.websockets.OCPPMessage;
+import com.sim_backend.websockets.OCPPMessageInfo;
+
+@OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_RESPONSE, messageName = "AuthorizeResponse")
+public class AuthorizeResponse extends OCPPMessage {
+
+    @SerializedName("status")
+    private String status;
+
+    // Constructor
+    public AuthorizeResponse(String status) {
+        this.status = status;
+    }
+
+    // Getter
+    public String getStatus() {
+        return status;
+    }
+
+    // Setter
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
@@ -1,36 +1,48 @@
 package com.sim_backend.websockets.messages;
 
+import com.google.gson.JsonArray;
+import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.OCPPMessage;
 import com.sim_backend.websockets.OCPPMessageInfo;
 
-/** A OCPP Boot Notification Message. */
-@OCPPMessageInfo(messageName = "BootNotification")
+/** A OCPP Boot Notification Request Message. */
+@OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_REQUEST, messageName = "BootNotification")
 public final class BootNotification extends OCPPMessage {
+
   /** The Charge Point's Vendor. */
+  @SerializedName("chargePointVendor")
   private final String chargePointVendor;
 
   /** The Charge Point's Model. */
+  @SerializedName("chargePointModel")
   private final String chargePointModel;
 
   /** The Charge Point's Serial Number. */
+  @SerializedName("chargePointSerialNumber")
   private final String chargePointSerialNumber;
 
   /** The Charge Box's Serial Number. */
+  @SerializedName("chargeBoxSerialNumber")
   private final String chargeBoxSerialNumber;
 
   /** Firmware Version. */
+  @SerializedName("firmwareVersion")
   private final String firmwareVersion;
 
-  /** ICCID. */
+  /** ICCID (Integrated Circuit Card Identifier) . */
+  @SerializedName("iccid")
   private final String iccid;
 
-  /** IMSI. */
+  /** IMSI (International Mobile Subscriber Identity). */
+  @SerializedName("imsi")
   private final String imsi;
 
   /** Meter Type. */
+  @SerializedName("meterType")
   private final String meterType;
 
   /** Meter Serial Number. */
+  @SerializedName("meterSerialNumber")
   private final String meterSerialNumber;
 
   /**
@@ -147,4 +159,5 @@ public final class BootNotification extends OCPPMessage {
   public String getMeterSerialNumber() {
     return meterSerialNumber;
   }
+
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
@@ -1,6 +1,5 @@
 package com.sim_backend.websockets.messages;
 
-import com.google.gson.JsonArray;
 import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.OCPPMessage;
 import com.sim_backend.websockets.OCPPMessageInfo;
@@ -68,6 +67,7 @@ public final class BootNotification extends OCPPMessage {
       final String inIMSI,
       final String mType,
       final String mSN) {
+    super();
     this.chargePointVendor = chargePVendor;
     this.chargePointModel = chargePModel;
     this.chargePointSerialNumber = chargePSN;
@@ -159,5 +159,4 @@ public final class BootNotification extends OCPPMessage {
   public String getMeterSerialNumber() {
     return meterSerialNumber;
   }
-
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
@@ -1,0 +1,37 @@
+package com.sim_backend.websockets.messages;
+import com.google.gson.annotations.SerializedName;
+import com.sim_backend.websockets.OCPPMessage;
+import com.sim_backend.websockets.OCPPMessageInfo;
+
+@OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_RESPONSE, messageName = "BootNotificationResponse")
+public class BootNotificationResponse extends OCPPMessage{
+
+    @SerializedName("status")
+    private String status;  // Status of the BootNotification (Accepted, Rejected)
+
+    @SerializedName("interval")
+    private int interval;   // Interval (time in seconds) for next BootNotification
+
+    // Constructor, getters, setters
+    public BootNotificationResponse(String status, int interval) {
+        this.status = status;
+        this.interval = interval;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public int getInterval() {
+        return interval;
+    }
+
+    public void setInterval(int interval) {
+        this.interval = interval;
+    }
+
+}

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
@@ -1,37 +1,40 @@
 package com.sim_backend.websockets.messages;
+
 import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.OCPPMessage;
 import com.sim_backend.websockets.OCPPMessageInfo;
 
-@OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_RESPONSE, messageName = "BootNotificationResponse")
-public class BootNotificationResponse extends OCPPMessage{
+@OCPPMessageInfo(
+    messageCallID = OCPPMessage.CALL_ID_RESPONSE,
+    messageName = "BootNotificationResponse")
+public class BootNotificationResponse extends OCPPMessage {
 
-    @SerializedName("status")
-    private String status;  // Status of the BootNotification (Accepted, Rejected)
+  @SerializedName("status")
+  private String status; // Status of the BootNotification (Accepted, Rejected)
 
-    @SerializedName("interval")
-    private int interval;   // Interval (time in seconds) for next BootNotification
+  @SerializedName("interval")
+  private int interval; // Interval (time in seconds) for next BootNotification
 
-    // Constructor, getters, setters
-    public BootNotificationResponse(String status, int interval) {
-        this.status = status;
-        this.interval = interval;
-    }
+  // Constructor, getters, setters
+  public BootNotificationResponse(String status, int interval) {
+    super();
+    this.status = status;
+    this.interval = interval;
+  }
 
-    public String getStatus() {
-        return status;
-    }
+  public String getStatus() {
+    return status;
+  }
 
-    public void setStatus(String status) {
-        this.status = status;
-    }
+  public void setStatus(String status) {
+    this.status = status;
+  }
 
-    public int getInterval() {
-        return interval;
-    }
+  public int getInterval() {
+    return interval;
+  }
 
-    public void setInterval(int interval) {
-        this.interval = interval;
-    }
-
+  public void setInterval(int interval) {
+    this.interval = interval;
+  }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/HeartBeat.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/HeartBeat.java
@@ -11,5 +11,4 @@ public final class HeartBeat extends OCPPMessage {
   public HeartBeat() {
     super();
   }
-
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/HeartBeat.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/HeartBeat.java
@@ -3,7 +3,7 @@ package com.sim_backend.websockets.messages;
 import com.sim_backend.websockets.OCPPMessage;
 import com.sim_backend.websockets.OCPPMessageInfo;
 
-@OCPPMessageInfo(messageName = "HeartBeat")
+@OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_REQUEST, messageName = "HeartBeat")
 public final class HeartBeat extends OCPPMessage {
   /***
    * A HeartBeat Message.
@@ -11,4 +11,5 @@ public final class HeartBeat extends OCPPMessage {
   public HeartBeat() {
     super();
   }
+
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/HeartBeatResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/HeartBeatResponse.java
@@ -5,7 +5,7 @@ import com.sim_backend.websockets.OCPPMessageInfo;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-@OCPPMessageInfo(messageName = "HeartBeatResponse", messageCallID = OCPPMessage.CALL_ID_RESPONSE)
+@OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_RESPONSE, messageName = "HeartBeatResponse")
 public final class HeartBeatResponse extends OCPPMessage {
 
   /** The HeartBeat's time. */


### PR DESCRIPTION
Adds both the response and requests for the three message types.

Still unsure about the JSON structure for the HeartBeat request (I think an empty JSON body is what's required but I saw an empty JSON array in other documentation). 

Added Gson serialization to existing HeartBeat and BootNotification files.

Also updated OCPP message Ids to be generated via UUID's for simplicity. 