### PR TITLE
Authorize   Boot Notification   Heartbeat   online/offline buttons

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Button } from './Button';
 
 function App() {
   const [message, setMessage] = useState('');
@@ -6,9 +7,9 @@ function App() {
   // Hook to fetch data from backend when the component mounts
   useEffect(() => {
     fetch(`${process.env.REACT_APP_BACKEND_URL}/api/test`)
-      .then(response => response.text())
-      .then(data => setMessage(data))
-      .catch(error => console.error('Error fetching test message:', error));
+      .then((response) => response.text())
+      .then((data) => setMessage(data))
+      .catch((error) => console.error('Error fetching test message:', error));
   }, []);
 
   // Render the component
@@ -16,6 +17,7 @@ function App() {
     <div>
       <h1>Frontend</h1>
       <p>Message from backend: {message}</p>
+      <Button />
     </div>
   );
 }

--- a/frontend/src/Button.js
+++ b/frontend/src/Button.js
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
 
+const messages = [
+  { name: 'Authorize', endpoint: '/api/message/authorize' },
+  { name: 'Boot', endpoint: '/api/message/boot' },
+  { name: 'Heartbeat', endpoint: '/api/message/heartbeat' },
+];
+
 //Generic method where each button POST request to the specified endpoint
-function sendRequest(endpoint, button) {
+function postRequest(endpoint, button) {
   return fetch(endpoint, {
     method: 'POST', //Add header and body after clarifying the request content
   })
@@ -31,7 +37,7 @@ function Button() {
   const handleOnlineOffline = () => {
     const endpoint = isOnline ? '/api/state/offline' : '/api/state/online';
     const buttonName = isOnline ? 'Take Offline' : 'Bring Online';
-    sendRequest(endpoint, buttonName).finally(() => {
+    postRequest(endpoint, buttonName).finally(() => {
       setIsOnline(!isOnline);
     });
   }; //Handle Bring online/Take Offline button click behavior, In offline state, the drop-down menu will not be displayed, which is in line with the example in the requirements document.
@@ -45,7 +51,7 @@ function Button() {
       {isOnline && (
         <>
           <button onClick={handleDropdown} style={{ marginRight: '10px' }}>
-            {openDropdown ? 'Close Menu' : 'Open Menu'}
+            {openDropdown ? 'Close Menu' : 'Send Messages'}
           </button>
           {openDropdown && (
             <div
@@ -60,30 +66,15 @@ function Button() {
                 flexDirection: 'column',
               }}
             >
-              <button
-                onClick={() =>
-                  sendRequest('/api/message/authorize', 'Authorize')
-                }
-                style={{ marginBottom: '8px' }}
-              >
-                Authorize
-              </button>
-              <button
-                onClick={() =>
-                  sendRequest('/api/message/boot', 'Boot Notification')
-                }
-                style={{ marginBottom: '8px' }}
-              >
-                Boot Notification
-              </button>
-              <button
-                onClick={() =>
-                  sendRequest('/api/message/heartbeat', 'Heartbeat')
-                }
-                style={{ marginBottom: '8px' }}
-              >
-                Heartbeat
-              </button>
+              {messages.map((message) => (
+                <button
+                  key={message.name}
+                  onClick={() => postRequest(message.endpoint, message.name)}
+                  style={{ marginBottom: '8px' }}
+                >
+                  {message.name}
+                </button>
+              ))}
             </div>
           )}
         </>

--- a/frontend/src/Button.js
+++ b/frontend/src/Button.js
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+
+//Generic method where each button POST request to the specified endpoint
+function sendRequest(endpoint, button) {
+  return fetch(endpoint, {
+    method: 'POST', //Add header and body after clarifying the request content
+  })
+    .then((response) => {
+      if (response.ok) {
+        console.log(`${button} button ${endpoint} request successful!`);
+        return response; // Request successful, return response for further processing
+      } else {
+        console.error(
+          `${button} button ${endpoint} request failed with status:`,
+          response.status
+        );
+        throw new Error(`Request failed with status ${response.status}`); //If the request fails, an exception is thrown
+      }
+    })
+    .catch((error) => {
+      console.error(`Error with ${endpoint}:`, error);
+      //Catch and log the exception
+    });
+}
+
+//Implementation of the button component, which includes a drop-down menu and an online/offline button
+function Button() {
+  const [isOnline, setIsOnline] = useState(false);
+  const [openDropdown, setOpenDropdown] = useState(false);
+
+  const handleOnlineOffline = () => {
+    const endpoint = isOnline ? '/api/state/offline' : '/api/state/online';
+    const buttonName = isOnline ? 'Take Offline' : 'Bring Online';
+    sendRequest(endpoint, buttonName).finally(() => {
+      setIsOnline(!isOnline);
+    });
+  }; //Handle Bring online/Take Offline button click behavior, In offline state, the drop-down menu will not be displayed, which is in line with the example in the requirements document.
+
+  const handleDropdown = () => {
+    setOpenDropdown(!openDropdown);
+  }; //Handle Dropdown menu open/close
+
+  return (
+    <div style={{ position: 'relative' }}>
+      {isOnline && (
+        <>
+          <button onClick={handleDropdown} style={{ marginRight: '10px' }}>
+            {openDropdown ? 'Close Menu' : 'Open Menu'}
+          </button>
+          {openDropdown && (
+            <div
+              style={{
+                position: 'absolute',
+                top: '100%',
+                border: '1px solid #ddd',
+                padding: '10px',
+                marginTop: '10px',
+                boxShadow: '0px 8px 16px rgba(0, 0, 0, 0.2)',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <button
+                onClick={() =>
+                  sendRequest('/api/message/authorize', 'Authorize')
+                }
+                style={{ marginBottom: '8px' }}
+              >
+                Authorize
+              </button>
+              <button
+                onClick={() =>
+                  sendRequest('/api/message/boot', 'Boot Notification')
+                }
+                style={{ marginBottom: '8px' }}
+              >
+                Boot Notification
+              </button>
+              <button
+                onClick={() =>
+                  sendRequest('/api/message/heartbeat', 'Heartbeat')
+                }
+                style={{ marginBottom: '8px' }}
+              >
+                Heartbeat
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      <button onClick={handleOnlineOffline} style={{ marginTop: '10px' }}>
+        {isOnline ? 'Take Offline' : 'Bring Online'}
+      </button>
+    </div>
+  );
+}
+
+export { Button };


### PR DESCRIPTION
I refer to the UX design of the requirements document. In offline state, there is only a "bring online button". Once online, a drop-down menu appears with Authorize, Boot Notification, and Heartbeat buttons. They will send a request to the endpoint. The request content is currently empty. The method of sending the request includes determining whether the request is successful or rejected, as well as exception handling.