### PR TITLE
CSCAP-53 Create endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ Use the linter on the backend
    lint_backend
 ```
 
-```bash
-   make docker
-```
+Compose and run docker file
 
 ```bash
    make docker

--- a/backend/src/main/java/com/sim_backend/Main.java
+++ b/backend/src/main/java/com/sim_backend/Main.java
@@ -1,7 +1,10 @@
 package com.sim_backend;
 
 import com.sim_backend.rest.TestMessageController;
+import com.sim_backend.rest.controllers.ControllerBase;
+import com.sim_backend.rest.controllers.MessageController;
 import io.javalin.Javalin;
+import java.net.URISyntaxException;
 
 public final class Main {
   private Main() {}
@@ -38,6 +41,13 @@ public final class Main {
                 })
             .start(backendPort); // Start the server
 
+    ControllerBase messageController = null;
+    try {
+      messageController = new MessageController(app);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    messageController.registerRoutes(app);
     // Register a test route
     TestMessageController.registerRoutes(app);
   }

--- a/backend/src/main/java/com/sim_backend/rest/controllers/ControllerBase.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/ControllerBase.java
@@ -1,0 +1,19 @@
+package com.sim_backend.rest.controllers;
+
+import io.javalin.Javalin;
+
+public abstract class ControllerBase {
+
+  protected final Javalin app;
+
+  public ControllerBase(Javalin app) {
+    this.app = app;
+  }
+
+  /**
+   * Registers all the routes handled by the controller.
+   *
+   * @param app The Javalin application instance
+   */
+  public abstract void registerRoutes(io.javalin.Javalin app);
+}

--- a/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
@@ -1,0 +1,73 @@
+/**
+ * Controller class for handling OCPP charging simulator messages and states. This includes
+ * processing authorize, boot, heartbeat, online, and offline requests.
+ *
+ * <p>The class interacts with the OCPPWebSocketClient to push messages to the backend and responds
+ * to HTTP POST requests from the front end. Each endpoint corresponds to a specific action (e.g.,
+ * authorize, boot, heartbeat) and allows the front end to trigger actions on the WebSocket client.
+ */
+package com.sim_backend.rest.controllers;
+
+import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.messages.Authorize;
+import com.sim_backend.websockets.messages.BootNotification;
+import com.sim_backend.websockets.messages.HeartBeat;
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class MessageController extends ControllerBase {
+
+  private OCPPWebSocketClient webSocketClient;
+
+  public MessageController(Javalin app) throws URISyntaxException {
+    super(app);
+    this.webSocketClient = new OCPPWebSocketClient(new URI(""));
+  }
+
+  private void authorize(Context ctx) {
+    Authorize msg = new Authorize();
+    webSocketClient.pushMessage(msg);
+    ctx.result("OK");
+  }
+
+  private void boot(Context ctx) {
+    BootNotification msg =
+        new BootNotification(
+            "CP Vendor",
+            "CP Model",
+            "CP S/N",
+            "Box S/N",
+            "Firmware",
+            "ICCID",
+            "IMSI",
+            "Meter Type",
+            "Meter S/N");
+    webSocketClient.pushMessage(msg);
+    ctx.result("OK");
+  }
+
+  private void heartbeat(Context ctx) {
+    HeartBeat msg = new HeartBeat();
+    webSocketClient.pushMessage(msg);
+    ctx.result("OK");
+  }
+
+  private void online(Context ctx) {
+    ctx.result("OK");
+  }
+
+  private void offline(Context ctx) {
+    ctx.result("OK");
+  }
+
+  @Override
+  public void registerRoutes(Javalin app) {
+    app.post("/api/message/authorize", this::authorize);
+    app.post("/api/message/boot", this::boot);
+    app.post("/api/message/heartbeat", this::heartbeat);
+    app.post("/api/state/online", this::online);
+    app.post("/api/state/offline", this::offline);
+  }
+}

--- a/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
@@ -16,7 +16,9 @@ import io.javalin.Javalin;
 import io.javalin.http.Context;
 import java.net.URI;
 import java.net.URISyntaxException;
+import lombok.Getter;
 
+@Getter
 public class MessageController extends ControllerBase {
 
   private OCPPWebSocketClient webSocketClient;
@@ -26,13 +28,13 @@ public class MessageController extends ControllerBase {
     this.webSocketClient = new OCPPWebSocketClient(new URI(""));
   }
 
-  private void authorize(Context ctx) {
+  public void authorize(Context ctx) {
     Authorize msg = new Authorize();
     webSocketClient.pushMessage(msg);
     ctx.result("OK");
   }
 
-  private void boot(Context ctx) {
+  public void boot(Context ctx) {
     BootNotification msg =
         new BootNotification(
             "CP Vendor",
@@ -48,17 +50,17 @@ public class MessageController extends ControllerBase {
     ctx.result("OK");
   }
 
-  private void heartbeat(Context ctx) {
+  public void heartbeat(Context ctx) {
     HeartBeat msg = new HeartBeat();
     webSocketClient.pushMessage(msg);
     ctx.result("OK");
   }
 
-  private void online(Context ctx) {
+  public void online(Context ctx) {
     ctx.result("OK");
   }
 
-  private void offline(Context ctx) {
+  public void offline(Context ctx) {
     ctx.result("OK");
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/enums/BootNotificationStatus.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/BootNotificationStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum BootStatus {
+public enum BootNotificationStatus {
   @SerializedName("Accepted")
   ACCEPTED("Accepted"),
 
@@ -18,8 +18,8 @@ public enum BootStatus {
 
   private final String value;
 
-  public static BootStatus fromString(String value) {
-    for (BootStatus status : BootStatus.values()) {
+  public static BootNotificationStatus fromString(String value) {
+    for (BootNotificationStatus status : BootNotificationStatus.values()) {
       if (status.value.equalsIgnoreCase(value)) {
         return status;
       }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
@@ -7,7 +7,7 @@ package com.sim_backend.websockets.messages;
 import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.OCPPMessage;
 import com.sim_backend.websockets.OCPPMessageInfo;
-import com.sim_backend.websockets.enums.BootStatus;
+import com.sim_backend.websockets.enums.BootNotificationStatus;
 import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,7 +22,7 @@ import lombok.Setter;
 public class BootNotificationResponse extends OCPPMessage {
 
   @SerializedName("status")
-  private BootStatus status; // Status of the BootNotification (Accepted, Rejected)
+  private BootNotificationStatus status; // Status of the BootNotification (Accepted, Rejected)
 
   @SerializedName("currentTime")
   private ZonedDateTime currentTime; // Current time in ISO 8601 format
@@ -31,7 +31,7 @@ public class BootNotificationResponse extends OCPPMessage {
   private int interval; // Interval (time in seconds) for next BootNotification
 
   public BootNotificationResponse(String status, ZonedDateTime currentTime, int interval) {
-    this.status = BootStatus.fromString(status);
+    this.status = BootNotificationStatus.fromString(status);
     this.currentTime = currentTime;
     this.interval = interval;
   }

--- a/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
+++ b/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
@@ -1,0 +1,107 @@
+package com.sim_backend.rest;
+
+import static org.mockito.Mockito.*;
+
+import com.sim_backend.rest.controllers.MessageController;
+import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.messages.Authorize;
+import com.sim_backend.websockets.messages.BootNotification;
+import com.sim_backend.websockets.messages.HeartBeat;
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+import java.net.URISyntaxException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class MessageControllerTest {
+
+  @Mock private Javalin mockApp;
+
+  @Mock private OCPPWebSocketClient mockWebSocketClient;
+
+  @Mock private Context mockContext;
+
+  private MessageController messageController;
+
+  @BeforeEach
+  void setUp() throws URISyntaxException {
+    MockitoAnnotations.openMocks(this);
+
+    // Create a spy or mock MessageController to allow partial mocking
+    messageController = spy(new MessageController(mockApp));
+
+    // Replace the actual WebSocketClient with the mock
+    // This requires making the webSocketClient field protected or package-private
+    // or using reflection to set the field
+    doReturn(mockWebSocketClient).when(messageController).getWebSocketClient();
+  }
+
+  @Test
+  void testAuthorize() {
+    // Arrange
+    doNothing().when(mockWebSocketClient).pushMessage(any(Authorize.class));
+
+    // Act
+    messageController.authorize(mockContext);
+
+    // Assert
+    verify(mockContext).result("OK");
+  }
+
+  @Test
+  void testBoot() {
+    // Arrange
+    doNothing().when(mockWebSocketClient).pushMessage(any(BootNotification.class));
+
+    // Act
+    messageController.boot(mockContext);
+
+    // Assert
+    verify(mockContext).result("OK");
+  }
+
+  @Test
+  void testHeartbeat() {
+    // Arrange
+    doNothing().when(mockWebSocketClient).pushMessage(any(HeartBeat.class));
+
+    // Act
+    messageController.heartbeat(mockContext);
+
+    // Assert
+    verify(mockContext).result("OK");
+  }
+
+  @Test
+  void testOnline() {
+    // Act
+    messageController.online(mockContext);
+
+    // Assert
+    verify(mockContext).result("OK");
+  }
+
+  @Test
+  void testOffline() {
+    // Act
+    messageController.offline(mockContext);
+
+    // Assert
+    verify(mockContext).result("OK");
+  }
+
+  @Test
+  void testRegisterRoutes() {
+    // Act
+    messageController.registerRoutes(mockApp);
+
+    // Assert
+    verify(mockApp).post(eq("/api/message/authorize"), any());
+    verify(mockApp).post(eq("/api/message/boot"), any());
+    verify(mockApp).post(eq("/api/message/heartbeat"), any());
+    verify(mockApp).post(eq("/api/state/online"), any());
+    verify(mockApp).post(eq("/api/state/offline"), any());
+  }
+}

--- a/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
@@ -28,7 +28,7 @@ public class BootNotificationResponseTest {
   public void testBootNotificationResponse() {
     ZonedDateTime testDateTime =
         ZonedDateTime.of(
-            2024, 11, 20, 20, 0, 0, 0, ZoneId.of("UTC") // Replace with desired ZoneId
+            2024, 11, 20, 20, 0, 0, 0, ZoneId.of("UTC")
             );
 
     BootNotificationResponse response = getBootNotificationResponse(testDateTime);

--- a/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
@@ -4,7 +4,7 @@ import com.networknt.schema.InputFormat;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.ValidationMessage;
 import com.sim_backend.websockets.GsonUtilities;
-import com.sim_backend.websockets.enums.BootStatus;
+import com.sim_backend.websockets.enums.BootNotificationStatus;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Set;
@@ -18,7 +18,7 @@ public class BootNotificationResponseTest {
     BootNotificationResponse response = new BootNotificationResponse("Accepted", dateTime, 5);
 
     assert response.getStatus().getValue().equals("Accepted");
-    assert response.getStatus() == BootStatus.ACCEPTED;
+    assert response.getStatus() == BootNotificationStatus.ACCEPTED;
     assert response.getCurrentTime() == dateTime;
     assert response.getInterval() == 5;
     return response;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,7 @@ function App() {
   return (
     <div>
       <h1>Frontend</h1>
-      <p data-testid="message">Message from backend: {message}</p>
+      <p data-testid="message">Message from backend: {message}</p> <Button />
     </div>
   );
 }


### PR DESCRIPTION
Creates the following post request endpoint that just return OK when hit:

/api/message/authorize

/api/message/boot

/api/message/heartbeat

/api/state/online

/api/state/offline

Barebones test added as well. 

Calling the endpoints via postman:
![image](https://github.com/user-attachments/assets/33671804-2ddd-48c2-a0d2-934ceebe4c7f)

Note: also refactored BootAuth name and fixed linter error for frontend. 
