### PR TITLE
Backend reformatting

### DIFF
--- a/backend/src/main/java/com/sim_backend/state/IndicatorLogger.java
+++ b/backend/src/main/java/com/sim_backend/state/IndicatorLogger.java
@@ -1,23 +1,17 @@
 package com.sim_backend.state;
 
 import java.util.*;
+import lombok.Getter;
 
+@Getter
 public class IndicatorLogger implements StateIndicator {
   private SimulatorState lastState;
-  private List<SimulatorState> stateHistory = new ArrayList<>();
+  private List<SimulatorState> history = new ArrayList<>();
 
   @Override
   public void onStateChanged(SimulatorState newState) {
     this.lastState = newState;
-    this.stateHistory.add(newState);
+    this.history.add(newState);
     System.out.println("State Changed to : " + newState);
-  }
-
-  public SimulatorState getLastState() {
-    return lastState;
-  }
-
-  public List<SimulatorState> getHistory() {
-    return stateHistory;
   }
 }

--- a/backend/src/main/java/com/sim_backend/state/SimulatorStateMachine.java
+++ b/backend/src/main/java/com/sim_backend/state/SimulatorStateMachine.java
@@ -1,9 +1,10 @@
 package com.sim_backend.state;
 
 import java.util.*;
+import lombok.Getter;
 
 public class SimulatorStateMachine {
-  private SimulatorState currentState;
+  @Getter private SimulatorState currentState;
   private Map<SimulatorState, Set<SimulatorState>> validTransitions = new HashMap<>();
   private List<StateIndicator> indicators = new ArrayList<>();
 
@@ -54,10 +55,5 @@ public class SimulatorStateMachine {
     for (StateIndicator indicator : indicators) {
       indicator.onStateChanged(currentState);
     }
-  }
-
-  // Getter
-  public SimulatorState getCurrentState() {
-    return currentState;
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -169,7 +169,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
         .ifPresent(
             listeners -> {
               for (OnOCPPMessageListener listener : listeners) {
-                listener.onMessageReceieved(new OnOCPPMessage(message));
+                listener.onMessageReceived(new OnOCPPMessage(message));
               }
             });
   }

--- a/backend/src/main/java/com/sim_backend/websockets/enums/ErrorCode.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
    * Payload for Action is syntactically correct but at least one of the fields violates occurrence
    * constraints.
    */
-  OccurrenceConstraintViolation,
+  OccurenceConstraintViolation,
   /**
    * Payload for Action is syntactically correct but at least one of the fields violates data type
    * constraints (e.g. “somestring”: 12)

--- a/backend/src/main/java/com/sim_backend/websockets/enums/ErrorCode.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
    * Payload for Action is syntactically correct but at least one of the fields violates occurrence
    * constraints.
    */
-  OccurenceConstraintViolation,
+  OccurrenceConstraintViolation,
   /**
    * Payload for Action is syntactically correct but at least one of the fields violates data type
    * constraints (e.g. “somestring”: 12)

--- a/backend/src/main/java/com/sim_backend/websockets/events/OnOCPPMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/events/OnOCPPMessage.java
@@ -1,8 +1,10 @@
 package com.sim_backend.websockets.events;
 
 import com.sim_backend.websockets.types.OCPPMessage;
+import lombok.Getter;
 
 /** An event for when we receive an OCPP message. */
+@Getter
 public class OnOCPPMessage {
   /** The received ocpp message. */
   private final OCPPMessage message;
@@ -14,14 +16,5 @@ public class OnOCPPMessage {
    */
   public OnOCPPMessage(final OCPPMessage inMessage) {
     this.message = inMessage;
-  }
-
-  /**
-   * Get the received OCPPMessage.
-   *
-   * @return The received message.
-   */
-  public OCPPMessage getMessage() {
-    return message;
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/events/OnOCPPMessageListener.java
+++ b/backend/src/main/java/com/sim_backend/websockets/events/OnOCPPMessageListener.java
@@ -7,5 +7,5 @@ public interface OnOCPPMessageListener {
    *
    * @param message The OCPP message event.
    */
-  void onMessageReceieved(OnOCPPMessage message);
+  void onMessageReceived(OnOCPPMessage message);
 }

--- a/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPCannotProcessResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPCannotProcessResponse.java
@@ -1,6 +1,9 @@
 package com.sim_backend.websockets.exceptions;
 
+import lombok.Getter;
+
 /** Thrown when we receive a message ID we did not send. */
+@Getter
 public class OCPPCannotProcessResponse extends Exception {
 
   /** The Received message we could not process due to us not having a matching message ID. */
@@ -18,16 +21,6 @@ public class OCPPCannotProcessResponse extends Exception {
   public OCPPCannotProcessResponse(final String receivedMsg, final String badMsgId) {
     this.receivedMessage = receivedMsg;
     this.badMessageId = badMsgId;
-  }
-
-  /** Get The unable to be matched messageID. */
-  public String getBadMessageId() {
-    return badMessageId;
-  }
-
-  /** Get the full message we received. */
-  public String getReceivedMessage() {
-    return receivedMessage;
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPMessageFailure.java
+++ b/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPMessageFailure.java
@@ -1,9 +1,11 @@
 package com.sim_backend.websockets.exceptions;
 
 import com.sim_backend.websockets.types.OCPPMessage;
+import lombok.Getter;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 
 /** Thrown when we could not send a message after a certain number of reattempts. */
+@Getter
 public class OCPPMessageFailure extends Exception {
 
   /** The Inner WebsocketException. */
@@ -23,24 +25,6 @@ public class OCPPMessageFailure extends Exception {
     super(message.toString());
     this.failedMessage = message;
     innerException = innerExp;
-  }
-
-  /**
-   * Get the Inner WebsocketException.
-   *
-   * @return The WebsocketNotConnectedException.
-   */
-  public WebsocketNotConnectedException getInnerException() {
-    return innerException;
-  }
-
-  /**
-   * Get the failed Message.
-   *
-   * @return The OCPPMessage that failed to send.
-   */
-  public OCPPMessage getFailedMessage() {
-    return failedMessage;
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPUnsupportedMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPUnsupportedMessage.java
@@ -1,5 +1,7 @@
 package com.sim_backend.websockets.exceptions;
 
+import lombok.Getter;
+
 /** Thrown when we receive an OCPP message name we cannot serialize. */
 public class OCPPUnsupportedMessage extends Exception {
 
@@ -7,7 +9,7 @@ public class OCPPUnsupportedMessage extends Exception {
   private final String message;
 
   /** The failed Message Name. */
-  private final String messageName;
+  @Getter private final String messageName;
 
   /**
    * An Exception thrown when we fail to process an OCPPMessage.
@@ -26,15 +28,6 @@ public class OCPPUnsupportedMessage extends Exception {
    */
   public String getFullMessage() {
     return message;
-  }
-
-  /**
-   * Get the message name of message we do not support.
-   *
-   * @return The Failed message name.
-   */
-  public String getMessageName() {
-    return messageName;
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessage.java
@@ -6,16 +6,15 @@ import com.google.gson.JsonArray;
 import com.sim_backend.websockets.GsonUtilities;
 import com.sim_backend.websockets.OCPPWebSocketClient;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
-import java.security.SecureRandom;
 import java.util.Set;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.reflections.Reflections;
 
 /** An OCPP message. */
 public abstract class OCPPMessage {
-  /** The maximum allowed message ID length. */
-  public static final int MAX_MESSAGE_ID_LENGTH = 20;
-
   /** The call ID for a request. */
   public static final int CALL_ID_REQUEST = 2;
 
@@ -29,7 +28,7 @@ public abstract class OCPPMessage {
   private transient int tries = 0;
 
   /** The Message ID we send this message with. */
-  protected transient String messageID;
+  @Getter @Setter protected transient String messageID;
 
   /** The constructor for an OCPP message. */
   protected OCPPMessage() {
@@ -66,43 +65,13 @@ public abstract class OCPPMessage {
   }
 
   /**
-   * Get the message ID.
-   *
-   * @return the current message ID.
-   */
-  public String getMessageID() {
-    return messageID;
-  }
-
-  /**
-   * Set the current message ID.
-   *
-   * @param msgID Set the message ID.
-   */
-  public void setMessageID(final String msgID) {
-    this.messageID = msgID;
-  }
-
-  /** The Characters we are allowed in a Message ID. */
-  private static final String CHARACTERS =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-  /** Our random generator. */
-  private static final SecureRandom RANDOM = new SecureRandom();
-
-  /**
-   * Generates a message ID of a given length.
+   * Generates a 36 Character UUID
    *
    * @return A randomly generated message ID.
    */
   @NotNull
   private static String generateMessageID() {
-    StringBuilder sb = new StringBuilder(OCPPMessage.MAX_MESSAGE_ID_LENGTH);
-    for (int i = 0; i < OCPPMessage.MAX_MESSAGE_ID_LENGTH; i++) {
-      int randomIndex = RANDOM.nextInt(CHARACTERS.length());
-      sb.append(CHARACTERS.charAt(randomIndex));
-    }
-    return sb.toString();
+    return UUID.randomUUID().toString();
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessageError.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessageError.java
@@ -4,8 +4,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.sim_backend.websockets.GsonUtilities;
 import com.sim_backend.websockets.enums.ErrorCode;
+import lombok.Getter;
 
 /** A CallError message for OCPP. */
+@Getter
 public class OCPPMessageError extends OCPPMessage {
 
   /** The message id index in a received JsonArray. */
@@ -20,13 +22,25 @@ public class OCPPMessageError extends OCPPMessage {
   /** The error details index in a received JsonArray. */
   private static final int DETAIL_INDEX = 4;
 
-  /** The given error code. */
+  /**
+   * The given error code. -- GETTER -- Get the error code.
+   *
+   * @return The given error code.
+   */
   private final transient ErrorCode errorCode;
 
-  /** The given error description. */
+  /**
+   * The given error description. -- GETTER -- Get the error description.
+   *
+   * @return The given error description.
+   */
   private final transient String errorDescription;
 
-  /** Any error details. */
+  /**
+   * Any error details. -- GETTER -- Get the error details JsonObject.
+   *
+   * @return The given Json Object.
+   */
   private final transient JsonObject errorDetails;
 
   /**
@@ -72,32 +86,5 @@ public class OCPPMessageError extends OCPPMessage {
     array.add(GsonUtilities.getGson().toJsonTree(this.errorDetails));
 
     return array;
-  }
-
-  /**
-   * Get the error details JsonObject.
-   *
-   * @return The given Json Object.
-   */
-  public JsonObject getErrorDetails() {
-    return errorDetails;
-  }
-
-  /**
-   * Get the error description.
-   *
-   * @return The given error description.
-   */
-  public String getErrorDescription() {
-    return errorDescription;
-  }
-
-  /**
-   * Get the error code.
-   *
-   * @return The given error code.
-   */
-  public ErrorCode getErrorCode() {
-    return errorCode;
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessageError.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessageError.java
@@ -22,25 +22,13 @@ public class OCPPMessageError extends OCPPMessage {
   /** The error details index in a received JsonArray. */
   private static final int DETAIL_INDEX = 4;
 
-  /**
-   * The given error code. -- GETTER -- Get the error code.
-   *
-   * @return The given error code.
-   */
+  /** The given error code. */
   private final transient ErrorCode errorCode;
 
-  /**
-   * The given error description. -- GETTER -- Get the error description.
-   *
-   * @return The given error description.
-   */
+  /** The given error description. */
   private final transient String errorDescription;
 
-  /**
-   * Any error details. -- GETTER -- Get the error details JsonObject.
-   *
-   * @return The given Json Object.
-   */
+  /** Any error details. */
   private final transient JsonObject errorDetails;
 
   /**


### PR DESCRIPTION
Went through some of the backend with IntelliJ and did some refactoring that it picked up.

- Like Authorize, OCPPMessage ID's generated via UUID for simplicity.
- Replace some existing setters/getters with Lombok annotations. 
- Some typos for functions and enum constants IntelliJ picked up were autocorrected. 

@JayQuack @Xerasin If removing the setters and getters isn't to your liking, we can decline the PR.