### PR TITLE
Add BootNotification constants

### DIFF
--- a/backend/src/main/java/com/sim_backend/websockets/constants/BootNotificationConstants.java
+++ b/backend/src/main/java/com/sim_backend/websockets/constants/BootNotificationConstants.java
@@ -1,0 +1,18 @@
+package com.sim_backend.websockets.constants;
+
+public final class BootNotificationConstants {
+
+  private BootNotificationConstants() {
+    // Private constructor to prevent instantiation
+  }
+
+  public static final String CHARGE_POINT_VENDOR = "SimulareVendor";
+  public static final String CHARGE_POINT_MODEL = "ModelForPSUCapstone";
+  public static final String CHARGE_POINT_SERIAL_NUMBER = "CPSN123456789012345";
+  public static final String CHARGE_BOX_SERIAL_NUMBER = "CBSN123456789012345";
+  public static final String FIRMWARE_VERSION = "FW_1.0.0_Version_2024";
+  public static final String ICCID = "ICCID1234567890123";
+  public static final String IMSI = "IMSI1234567890123";
+  public static final String METER_TYPE = "MeterType123";
+  public static final String METER_SERIAL_NUMBER = "MSN123456789012345";
+}

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
@@ -6,6 +6,7 @@ package com.sim_backend.websockets.messages;
 
 import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
+import com.sim_backend.websockets.constants.BootNotificationConstants;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageRequest;
 import lombok.AllArgsConstructor;
@@ -52,4 +53,17 @@ public final class BootNotification extends OCPPMessageRequest {
   /** Meter Serial Number. */
   @SerializedName("meterSerialNumber")
   private final String meterSerialNumber;
+
+  // Default constructor, makes use of the BootNotificationConstants
+  public BootNotification() {
+    this.chargePointVendor = BootNotificationConstants.CHARGE_POINT_VENDOR;
+    this.chargePointModel = BootNotificationConstants.CHARGE_POINT_MODEL;
+    this.chargePointSerialNumber = BootNotificationConstants.CHARGE_POINT_SERIAL_NUMBER;
+    this.chargeBoxSerialNumber = BootNotificationConstants.CHARGE_BOX_SERIAL_NUMBER;
+    this.firmwareVersion = BootNotificationConstants.FIRMWARE_VERSION;
+    this.iccid = BootNotificationConstants.ICCID;
+    this.imsi = BootNotificationConstants.IMSI;
+    this.meterType = BootNotificationConstants.METER_TYPE;
+    this.meterSerialNumber = BootNotificationConstants.METER_SERIAL_NUMBER;
+  }
 }


### PR DESCRIPTION
Creates a simple constants class for boot notification requests. Adds a new default constructor to BootNotification to make use of the constants.

The ticket calls for both boot notification and authorize to be done, but as far as I can tell this isn't needed for Authorize as it only has one field tag that is automatically generated upon being created. 