### PR TITLE
Cscap 64 Boot Observer

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -51,6 +51,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>0.8.12</version>

--- a/backend/src/main/java/com/sim_backend/Main.java
+++ b/backend/src/main/java/com/sim_backend/Main.java
@@ -3,7 +3,9 @@ package com.sim_backend;
 import com.sim_backend.rest.TestMessageController;
 import com.sim_backend.rest.controllers.ControllerBase;
 import com.sim_backend.rest.controllers.MessageController;
+import com.sim_backend.state.SimulatorStateMachine;
 import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.observers.BootNotificationObserver;
 import io.javalin.Javalin;
 import java.net.URI;
 
@@ -27,6 +29,12 @@ public final class Main {
 
     // Run the main simulator loop
     SimulatorLoop.runSimulatorLoop(wsClient);
+
+    // Create Simulator State
+    SimulatorStateMachine stateMachine = new SimulatorStateMachine();
+    // Create Observers
+    // TODO: Add other observers
+    BootNotificationObserver bootObserver = new BootNotificationObserver(wsClient, stateMachine);
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/Main.java
+++ b/backend/src/main/java/com/sim_backend/Main.java
@@ -27,14 +27,15 @@ public final class Main {
     // Register REST API controllers and routes
     registerRoutes(app, wsClient);
 
-    // Run the main simulator loop
-    SimulatorLoop.runSimulatorLoop(wsClient);
-
     // Create Simulator State
     SimulatorStateMachine stateMachine = new SimulatorStateMachine();
     // Create Observers
     // TODO: Add other observers
     BootNotificationObserver bootObserver = new BootNotificationObserver(wsClient, stateMachine);
+
+    // Run the main simulator loop
+    SimulatorLoop.runSimulatorLoop(wsClient);
+
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
+++ b/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
@@ -46,7 +46,7 @@ public class MessageScheduler {
   /**
    * Our set heartbeat interval, we don't want this too common but every 4 minutes should be enough.
    */
-  private static final long HEARTBEAT_INTERVAL = 240L; // seconds
+  @Getter private static final long HEARTBEAT_INTERVAL = 240L; // seconds
 
   /** Our heartbeat job. */
   private TimedTask heartbeat;

--- a/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
+++ b/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
@@ -77,6 +77,10 @@ public class MessageScheduler {
     return (this.heartbeat = this.periodicJob(0, interval, unit, new Heartbeat()));
   }
 
+  /**
+   * Sets the OCPPTime to match that of the Central Server
+   * @param time The time of the Central Server to synchronize to
+   */
   public void synchronizeTime(ZonedDateTime time) {
     this.time.setOffset(time);
   }

--- a/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
+++ b/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
@@ -77,6 +77,10 @@ public class MessageScheduler {
     return (this.heartbeat = this.periodicJob(0, interval, unit, new Heartbeat()));
   }
 
+  public void synchronizeTime(ZonedDateTime time) {
+    this.time.setOffset(time);
+  }
+
   /**
    * Create a Runnable instance for our job functions.
    *

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPTime.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPTime.java
@@ -67,14 +67,13 @@ public class OCPPTime implements AutoCloseable {
   }
 
   /**
-   * Synchronizes the clock to match the Central System's current time.
-   * Used when a BootNotificationResponse returns an Accepted status.
+   * Synchronizes the clock to match the Central System's current time. Used when a
+   * BootNotificationResponse returns an Accepted status.
    *
    * @param time the time you wish to sync up.
    */
-  public void setOffset(ZonedDateTime time){
-    Duration calculatedOffset =
-            Duration.between(ZonedDateTime.now(UTC), time);
+  public void setOffset(ZonedDateTime time) {
+    Duration calculatedOffset = Duration.between(ZonedDateTime.now(UTC), time);
     offset.set(calculatedOffset);
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPTime.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPTime.java
@@ -23,11 +23,7 @@ public class OCPPTime implements AutoCloseable {
   final OnOCPPMessageListener listener =
       message -> {
         HeartbeatResponse response = (HeartbeatResponse) message.getMessage();
-
-        // Always work in UTC
-        Duration calculatedOffset =
-            Duration.between(ZonedDateTime.now(UTC), response.getCurrentTime());
-        offset.set(calculatedOffset);
+        setOffset(response.getCurrentTime());
       };
 
   /** The client we are listening on. */

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPTime.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPTime.java
@@ -67,6 +67,18 @@ public class OCPPTime implements AutoCloseable {
   }
 
   /**
+   * Synchronizes the clock to match the Central System's current time.
+   * Used when a BootNotificationResponse returns an Accepted status.
+   *
+   * @param time the time you wish to sync up.
+   */
+  public void setOffset(ZonedDateTime time){
+    Duration calculatedOffset =
+            Duration.between(ZonedDateTime.now(UTC), time);
+    offset.set(calculatedOffset);
+  }
+
+  /**
    * Called when this is destroyed in a try catch.
    *
    * @throws Exception error in removing the receiver.

--- a/backend/src/main/java/com/sim_backend/websockets/enums/RegistrationStatus.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/RegistrationStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum BootNotificationStatus {
+public enum RegistrationStatus {
   @SerializedName("Accepted")
   ACCEPTED("Accepted"),
 
@@ -18,8 +18,8 @@ public enum BootNotificationStatus {
 
   private final String value;
 
-  public static BootNotificationStatus fromString(String value) {
-    for (BootNotificationStatus status : BootNotificationStatus.values()) {
+  public static RegistrationStatus fromString(String value) {
+    for (RegistrationStatus status : RegistrationStatus.values()) {
       if (status.value.equalsIgnoreCase(value)) {
         return status;
       }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
@@ -2,7 +2,7 @@ package com.sim_backend.websockets.messages;
 
 import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
-import com.sim_backend.websockets.enums.BootNotificationStatus;
+import com.sim_backend.websockets.enums.RegistrationStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
 import java.time.ZonedDateTime;
@@ -23,7 +23,7 @@ import lombok.Setter;
 public class BootNotificationResponse extends OCPPMessageResponse {
 
   @SerializedName("status")
-  private BootNotificationStatus status; // Status of the BootNotification (Accepted, Rejected)
+  private RegistrationStatus status; // Status of the BootNotification (Accepted, Rejected)
 
   @SerializedName("currentTime")
   private ZonedDateTime currentTime; // Current time in ISO 8601 format
@@ -32,7 +32,7 @@ public class BootNotificationResponse extends OCPPMessageResponse {
   private int interval; // Interval (time in seconds) for next BootNotification
 
   public BootNotificationResponse(String status, ZonedDateTime currentTime, int interval) {
-    this.status = BootNotificationStatus.fromString(status);
+    this.status = RegistrationStatus.fromString(status);
     this.currentTime = currentTime;
     this.interval = interval;
   }

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -53,7 +53,8 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateInd
 
     switch (response.getStatus()) {
       case ACCEPTED:
-        // Registration successful, set heartbeat from interval
+        // Registration successful, set heartbeat from interval, update state
+        // and synchronize time to match the Central System.
         scheduler.setHeartbeatInterval(interval, TimeUnit.SECONDS);
         currState.transition(SimulatorState.Available);
         scheduler.synchronizeTime(response.getCurrentTime());

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -1,29 +1,74 @@
 package com.sim_backend.websockets.observers;
 
+import com.sim_backend.state.IllegalStateException;
 import com.sim_backend.state.SimulatorState;
 import com.sim_backend.state.SimulatorStateMachine;
+import com.sim_backend.websockets.MessageScheduler;
 import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.events.OnOCPPMessage;
+import com.sim_backend.websockets.events.OnOCPPMessageListener;
 import com.sim_backend.websockets.messages.BootNotification;
 import com.sim_backend.websockets.messages.BootNotificationResponse;
+import java.util.concurrent.TimeUnit;
 
-public class BootNotificationObserver {
+/**
+ * Observer that handles BootNotification requests and responses
+ * as part of the OCPP protocol communication with the Central System.
+ */
+public class BootNotificationObserver implements OnOCPPMessageListener {
 
-    private OCPPWebSocketClient webSocketClient;
+  private OCPPWebSocketClient webSocketClient;
 
-    private void handleBootNotificationRequest(SimulatorStateMachine currState, BootNotification request) {
+  /**
+   * Handles sending a BootNotification request to the Central System if the simulator
+   * is in the correct state.
+   *
+   * @param currState the current state machine of the simulator.
+   * @throws IllegalStateException if the simulator is not in the booting state.
+   */
+  public void handleBootNotificationRequest(SimulatorStateMachine currState) {
 
-        // Create the BootNotification request
+    // Ensure current state is booting
+    if (currState.getCurrentState() == SimulatorState.BootingUp) {
+      webSocketClient.pushMessage(new BootNotification());
+    } else
+      throw new IllegalStateException(
+          "Invalid machine state to send a boot notification: " + currState.getCurrentState());
+  }
 
-        // Current state is booting
-        if(currState.getCurrentState() == SimulatorState.BootingUp){
-            // TODO: Validate request here
-            webSocketClient.pushMessage(request);
+  /**
+   * Processes incoming BootNotificationResponse messages and handles the response based on
+   * the registration status provided by the Central System.
+   *
+   * @param message the received OCPP message, expected to be a BootNotificationResponse.
+   * @throws ClassCastException if the message is not a BootNotificationResponse.
+   */
+  @Override
+  public void onMessageReceived(OnOCPPMessage message) {
+
+    if (!(message.getMessage() instanceof BootNotificationResponse response))
+      throw new ClassCastException("Message is not a BootNotificationResponse");
+    MessageScheduler scheduler = message.getClient().getScheduler();
+    long interval = response.getInterval();
+
+    switch (response.getStatus()) {
+      case ACCEPTED:
+        // Registration successful, set heartbeat from interval
+        scheduler.setHeartbeatInterval(interval, TimeUnit.SECONDS);
+        break;
+
+      case PENDING, REJECTED:
+        // Central system is pending, set minimum wait time before next BootNotification request
+        if (interval <= 0) {
+          // Use default heartbeat interval if none given from central system.
+          interval = MessageScheduler.getHEARTBEAT_INTERVAL();
         }
+        scheduler.registerJob(interval, TimeUnit.SECONDS, new BootNotification());
+        break;
 
+      default:
+        System.err.println("Unknown status received in BootNotificationResponse.");
+        break;
     }
-
-    // Received a BootNotification Response back from recipient backend
-    private void handleBootNotificationResponse(BootNotificationResponse response) {
-
-    }
+  }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -1,0 +1,29 @@
+package com.sim_backend.websockets.observers;
+
+import com.sim_backend.state.SimulatorState;
+import com.sim_backend.state.SimulatorStateMachine;
+import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.messages.BootNotification;
+import com.sim_backend.websockets.messages.BootNotificationResponse;
+
+public class BootNotificationObserver {
+
+    private OCPPWebSocketClient webSocketClient;
+
+    private void handleBootNotificationRequest(SimulatorStateMachine currState, BootNotification request) {
+
+        // Create the BootNotification request
+
+        // Current state is booting
+        if(currState.getCurrentState() == SimulatorState.BootingUp){
+            // TODO: Validate request here
+            webSocketClient.pushMessage(request);
+        }
+
+    }
+
+    // Received a BootNotification Response back from recipient backend
+    private void handleBootNotificationResponse(BootNotificationResponse response) {
+
+    }
+}

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -12,16 +12,16 @@ import com.sim_backend.websockets.messages.BootNotificationResponse;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Observer that handles BootNotification requests and responses
- * as part of the OCPP protocol communication with the Central System.
+ * Observer that handles BootNotification requests and responses as part of the OCPP protocol
+ * communication with the Central System.
  */
 public class BootNotificationObserver implements OnOCPPMessageListener {
 
   private OCPPWebSocketClient webSocketClient;
 
   /**
-   * Handles sending a BootNotification request to the Central System if the simulator
-   * is in the correct state.
+   * Handles sending a BootNotification request to the Central System if the simulator is in the
+   * correct state.
    *
    * @param currState the current state machine of the simulator.
    * @throws IllegalStateException if the simulator is not in the booting state.
@@ -37,8 +37,8 @@ public class BootNotificationObserver implements OnOCPPMessageListener {
   }
 
   /**
-   * Processes incoming BootNotificationResponse messages and handles the response based on
-   * the registration status provided by the Central System.
+   * Processes incoming BootNotificationResponse messages and handles the response based on the
+   * registration status provided by the Central System.
    *
    * @param message the received OCPP message, expected to be a BootNotificationResponse.
    * @throws ClassCastException if the message is not a BootNotificationResponse.

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -59,10 +59,15 @@ public class BootNotificationObserver implements OnOCPPMessageListener {
       case PENDING, REJECTED:
         // Central system is pending or rejected the request, set minimum wait time before next
         // BootNotification request
-        if (interval <= 0) {
+        if (interval < 0){
+          throw new IllegalArgumentException("Invalid heartbeat interval: " + interval);
+        }
+
+        if (interval == 0) {
           // Use default heartbeat interval if none given from central system.
           interval = MessageScheduler.getHEARTBEAT_INTERVAL();
         }
+
         scheduler.registerJob(interval, TimeUnit.SECONDS, new BootNotification());
         break;
 

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -56,7 +56,7 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateInd
         // Registration successful, set heartbeat from interval
         scheduler.setHeartbeatInterval(interval, TimeUnit.SECONDS);
         currState.transition(SimulatorState.Available);
-
+        scheduler.synchronizeTime(response.getCurrentTime());
         break;
 
       case PENDING, REJECTED:

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -57,7 +57,8 @@ public class BootNotificationObserver implements OnOCPPMessageListener {
         break;
 
       case PENDING, REJECTED:
-        // Central system is pending, set minimum wait time before next BootNotification request
+        // Central system is pending or rejected the request, set minimum wait time before next
+        // BootNotification request
         if (interval <= 0) {
           // Use default heartbeat interval if none given from central system.
           interval = MessageScheduler.getHEARTBEAT_INTERVAL();

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -17,8 +17,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class BootNotificationObserver implements OnOCPPMessageListener {
 
-  private OCPPWebSocketClient webSocketClient;
-
   /**
    * Handles sending a BootNotification request to the Central System if the simulator is in the
    * correct state.
@@ -26,7 +24,8 @@ public class BootNotificationObserver implements OnOCPPMessageListener {
    * @param currState the current state machine of the simulator.
    * @throws IllegalStateException if the simulator is not in the booting state.
    */
-  public void handleBootNotificationRequest(SimulatorStateMachine currState) {
+  public void handleBootNotificationRequest(
+      OCPPWebSocketClient webSocketClient, SimulatorStateMachine currState) {
 
     // Ensure current state is booting
     if (currState.getCurrentState() == SimulatorState.BootingUp) {

--- a/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
@@ -4,7 +4,7 @@ import com.networknt.schema.InputFormat;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.ValidationMessage;
 import com.sim_backend.websockets.GsonUtilities;
-import com.sim_backend.websockets.enums.BootNotificationStatus;
+import com.sim_backend.websockets.enums.RegistrationStatus;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Set;
@@ -18,7 +18,7 @@ public class BootNotificationResponseTest {
     BootNotificationResponse response = new BootNotificationResponse("Accepted", dateTime, 5);
 
     assert response.getStatus().getValue().equals("Accepted");
-    assert response.getStatus() == BootNotificationStatus.ACCEPTED;
+    assert response.getStatus() == RegistrationStatus.ACCEPTED;
     assert response.getCurrentTime() == dateTime;
     assert response.getInterval() == 5;
     return response;

--- a/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
@@ -35,14 +35,6 @@ class BootNotificationObserverTest {
   @BeforeEach
   void setUp() {
     observer = new BootNotificationObserver();
-    try {
-      java.lang.reflect.Field field =
-          BootNotificationObserver.class.getDeclaredField("webSocketClient");
-      field.setAccessible(true);
-      field.set(observer, webSocketClient);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to set webSocketClient field", e);
-    }
   }
 
   @Test
@@ -52,7 +44,7 @@ class BootNotificationObserverTest {
     when(stateMachine.getCurrentState()).thenReturn(SimulatorState.BootingUp);
 
     // Act
-    observer.handleBootNotificationRequest(stateMachine);
+    observer.handleBootNotificationRequest(webSocketClient, stateMachine);
 
     // Assert
     verify(webSocketClient).pushMessage(isBootNotification());
@@ -66,7 +58,8 @@ class BootNotificationObserverTest {
 
     // Act & Assert
     org.junit.jupiter.api.Assertions.assertThrows(
-        IllegalStateException.class, () -> observer.handleBootNotificationRequest(stateMachine));
+        IllegalStateException.class,
+        () -> observer.handleBootNotificationRequest(webSocketClient, stateMachine));
   }
 
   @Test

--- a/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
@@ -1,0 +1,153 @@
+package com.sim_backend.websockets.observers;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import com.sim_backend.state.IllegalStateException;
+import com.sim_backend.state.SimulatorState;
+import com.sim_backend.state.SimulatorStateMachine;
+import com.sim_backend.websockets.MessageScheduler;
+import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.enums.RegistrationStatus;
+import com.sim_backend.websockets.events.OnOCPPMessage;
+import com.sim_backend.websockets.messages.BootNotification;
+import com.sim_backend.websockets.messages.BootNotificationResponse;
+import com.sim_backend.websockets.types.OCPPMessage;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BootNotificationObserverTest {
+
+  @Mock private OCPPWebSocketClient webSocketClient;
+
+  private BootNotificationObserver observer;
+
+  private static BootNotification isBootNotification() {
+    return argThat(argument -> argument instanceof BootNotification);
+  }
+
+  @BeforeEach
+  void setUp() {
+    observer = new BootNotificationObserver();
+    try {
+      java.lang.reflect.Field field =
+          BootNotificationObserver.class.getDeclaredField("webSocketClient");
+      field.setAccessible(true);
+      field.set(observer, webSocketClient);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set webSocketClient field", e);
+    }
+  }
+
+  @Test
+  void handleBootNotificationRequest_WhenBooting_SendsNotification() {
+    // Arrange
+    SimulatorStateMachine stateMachine = mock(SimulatorStateMachine.class);
+    when(stateMachine.getCurrentState()).thenReturn(SimulatorState.BootingUp);
+
+    // Act
+    observer.handleBootNotificationRequest(stateMachine);
+
+    // Assert
+    verify(webSocketClient).pushMessage(isBootNotification());
+  }
+
+  @Test
+  void handleBootNotificationRequest_WhenNotBooting_ThrowsException() {
+    // Arrange
+    SimulatorStateMachine stateMachine = mock(SimulatorStateMachine.class);
+    when(stateMachine.getCurrentState()).thenReturn(SimulatorState.Available);
+
+    // Act & Assert
+    org.junit.jupiter.api.Assertions.assertThrows(
+        IllegalStateException.class, () -> observer.handleBootNotificationRequest(stateMachine));
+  }
+
+  @Test
+  void onMessageReceived_WhenStatusAccepted_SetsHeartbeat() {
+    // Arrange
+    BootNotificationResponse response = mock(BootNotificationResponse.class);
+    when(response.getStatus()).thenReturn(RegistrationStatus.ACCEPTED);
+    when(response.getInterval()).thenReturn(30);
+
+    OCPPWebSocketClient client = mock(OCPPWebSocketClient.class);
+    MessageScheduler messageScheduler = mock(MessageScheduler.class);
+    when(client.getScheduler()).thenReturn(messageScheduler);
+
+    OnOCPPMessage message = mock(OnOCPPMessage.class);
+    when(message.getMessage()).thenReturn(response);
+    when(message.getClient()).thenReturn(client);
+
+    // Act
+    observer.onMessageReceived(message);
+
+    // Assert
+    verify(messageScheduler).setHeartbeatInterval(30L, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void onMessageReceived_WhenStatusPending_RegistersJob() {
+    // Arrange
+    BootNotificationResponse response = mock(BootNotificationResponse.class);
+    when(response.getStatus()).thenReturn(RegistrationStatus.PENDING);
+    when(response.getInterval()).thenReturn(15);
+
+    OCPPWebSocketClient client = mock(OCPPWebSocketClient.class);
+    MessageScheduler messageScheduler = mock(MessageScheduler.class);
+    when(client.getScheduler()).thenReturn(messageScheduler);
+
+    OnOCPPMessage message = mock(OnOCPPMessage.class);
+    when(message.getMessage()).thenReturn(response);
+    when(message.getClient()).thenReturn(client);
+
+    // Act
+    observer.onMessageReceived(message);
+
+    // Assert
+    verify(messageScheduler).registerJob(eq(15L), eq(TimeUnit.SECONDS), isBootNotification());
+  }
+
+  @Test
+  void onMessageReceived_WhenStatusRejected_RegistersJob() {
+    // Arrange
+    BootNotificationResponse response = mock(BootNotificationResponse.class);
+    when(response.getStatus()).thenReturn(RegistrationStatus.REJECTED);
+    when(response.getInterval()).thenReturn(0);
+
+    OCPPWebSocketClient client = mock(OCPPWebSocketClient.class);
+    MessageScheduler messageScheduler = mock(MessageScheduler.class);
+    when(client.getScheduler()).thenReturn(messageScheduler);
+
+    OnOCPPMessage message = mock(OnOCPPMessage.class);
+    when(message.getMessage()).thenReturn(response);
+    when(message.getClient()).thenReturn(client);
+
+    // Act
+    observer.onMessageReceived(message);
+
+    // Assert
+    verify(messageScheduler)
+        .registerJob(
+            eq(MessageScheduler.getHEARTBEAT_INTERVAL()),
+            eq(TimeUnit.SECONDS),
+            isBootNotification());
+  }
+
+  @Test
+  void onMessageReceived_WhenInvalidMessageType_ThrowsException() {
+    // Arrange
+    OCPPMessage invalidMessage = mock(OCPPMessage.class);
+    OnOCPPMessage message = mock(OnOCPPMessage.class);
+    when(message.getMessage()).thenReturn(invalidMessage);
+
+    // Act & Assert
+    org.junit.jupiter.api.Assertions.assertThrows(
+        ClassCastException.class, () -> observer.onMessageReceived(message));
+  }
+}


### PR DESCRIPTION
Creates a BootNotificationObserver:

- Has a handler to be used by the controller for requests
- Implements OnOCPPMessageListener's onMessageReceived for processing a BootNotificationResponse
- Tests created

Additionally renamed the BootNotificationStatus -> RegistrationStatus to match OCPP spec naming. 