### PR TITLE
Add debugging options for docker builds (CSCAP-34)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "configurations": [
+      {
+        "name": "Attach to Backend Debugger",
+        "type": "java",
+        "request": "attach",
+        "hostName": "localhost",
+        "port": 5005
+      }
+    ]
+  }
+  

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@
 docker:
 	docker-compose --profile core up --build
 
+docker_debug:
+	DEBUG_STAGE=suspend-debug docker-compose --profile core up --build
+
 integration_test:
-	docker-compose --env-file .env.internal --profile integration-test up --build
+	DEBUG_STAGE=run-debug docker-compose --env-file .env.internal --profile integration-test up --build
 
 build_backend:
 	cd ./backend && mvn spotless:apply && mvn clean && mvn package

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,10 +22,33 @@ COPY --from=build /app/target/ocpp-charger-sim-backend-1.0-SNAPSHOT.jar /app/app
 # Expose the backend port
 EXPOSE ${BACKEND_PORT}
 
-# Run the application
 CMD ["java", "-jar", "/app/app.jar"]
 
-# Run tests
+# Stage 3: Run with debugging
+FROM build AS run-debug
+
+# Copy the packaged jar file from the build stage
+COPY --from=build /app/target/ocpp-charger-sim-backend-1.0-SNAPSHOT.jar /app/app.jar
+
+# Expose the backend port and debug port
+EXPOSE ${BACKEND_PORT}
+EXPOSE ${DEBUG_PORT:-5005}
+
+CMD ["sh", "-c", "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:${DEBUG_PORT:-5005} -jar /app/app.jar"]
+
+# Stage 4: Run with debugging, start suspended
+FROM build AS suspend-debug
+
+# Copy the packaged jar file from the build stage
+COPY --from=build /app/target/ocpp-charger-sim-backend-1.0-SNAPSHOT.jar /app/app.jar
+
+# Expose the backend port and debug port
+EXPOSE ${BACKEND_PORT}
+EXPOSE ${DEBUG_PORT:-5005}
+
+CMD ["sh", "-c", "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:${DEBUG_PORT:-5005} -jar /app/app.jar"]
+
+# Stage 5: Run Tests
 FROM build AS test
 
 # Set the working directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,15 @@ services:
   backend:
     build:
       context: ./backend
-      target: run
+      target: ${DEBUG_STAGE:-run}
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"
+      - "5005:5005"
     environment:
       - BACKEND_HOST=${BACKEND_HOST}
       - BACKEND_PORT=${BACKEND_PORT}
       - FRONTEND_URL=http://${FRONTEND_HOST}:${FRONTEND_PORT}
+      - DEBUG_PORT=5005
     profiles:
       - core
       - integration-test

--- a/integration_test/tests/Messages.cy.js
+++ b/integration_test/tests/Messages.cy.js
@@ -22,7 +22,7 @@ describe("Stateless OCPP message test", () => {
 
     // Verify the HeartBeat message
     getLastMessage().then((messageArray) => {
-      verifyCallFields(messageArray, "HeartBeat");
+      verifyCallFields(messageArray, "Heartbeat");
       expect(messageArray[3]).to.deep.eq({}); // Verify empty payload
     });
   });


### PR DESCRIPTION
The debugging is started in suspended mode for non-integration test builds. This allows you to attach to the debugging port, 5005, before the backend starts running.

Also adds a launch.json for debugging in VS Code.