### PR TITLE
Run frontend tests on PRs (CSCAP-77)

### DIFF
--- a/.github/workflows/01-jacoco.yml
+++ b/.github/workflows/01-jacoco.yml
@@ -2,6 +2,8 @@ name: Measure coverage
 
 on:
   pull_request:
+    paths:
+      - 'backend/**'
 
 jobs:
   build:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,31 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: npm install
+
+      - name: Run tests
+        working-directory: ./frontend
+        env:
+          CI: true
+        run: npm test


### PR DESCRIPTION
Frontend tests will only run on PRs that have changes in frontend/\*\*.
Also change backend coverage runs to only run when a file in backend/\*\* was changed.

See this [closed PR](https://github.com/pglob/ocpp-charger-sim/pull/38) for testing of the GitHub workflow