### PR TITLE
Cscap 98/WS Connection Compliance

### DIFF
--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -80,7 +80,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
   public void onOpen(ServerHandshake serverHandshake) {
     String protocol = serverHandshake.getFieldValue("Sec-WebSocket-Protocol");
     if (protocol == null || !protocol.contains("ocpp1.6")) {
-      log.error("Websocket Handshake failed ocpp1.6 is not supported: {}", protocol);
+      log.error("Handshake failed no supported protocols provided: {}", protocol);
       throw new OCPPUnsupportedProtocol(protocol);
     }
   }

--- a/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPUnsupportedProtocol.java
+++ b/backend/src/main/java/com/sim_backend/websockets/exceptions/OCPPUnsupportedProtocol.java
@@ -1,0 +1,10 @@
+package com.sim_backend.websockets.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OCPPUnsupportedProtocol extends RuntimeException {
+  public String protocol;
+}

--- a/dummy_server/DummyServer.js
+++ b/dummy_server/DummyServer.js
@@ -7,7 +7,7 @@ app.use(express.json());
 const receivedMessages = [];
 
 // WebSocket server
-const wss = new WebSocket.Server({
+const wss = new WebSocketServer({
   port: 9000,
   handleProtocols: (protocols, request) => {
     if (protocols.includes("ocpp1.6")) {

--- a/dummy_server/DummyServer.js
+++ b/dummy_server/DummyServer.js
@@ -7,7 +7,18 @@ app.use(express.json());
 const receivedMessages = [];
 
 // WebSocket server
-const wss = new WebSocketServer({ port: 9000 });
+const wss = new WebSocket.Server({
+  port: 9000,
+  handleProtocols: (protocols, request) => {
+    if (protocols.includes("ocpp1.6")) {
+      return "ocpp1.6";
+    }
+
+    console.error("No supported subprotocol found");
+    return false;
+  },
+});
+
 wss.on("connection", (ws) => {
   console.log("WebSocket connection established");
 

--- a/dummy_server/DummyServer.js
+++ b/dummy_server/DummyServer.js
@@ -10,7 +10,7 @@ const receivedMessages = [];
 const wss = new WebSocketServer({
   port: 9000,
   handleProtocols: (protocols, request) => {
-    if (protocols.includes("ocpp1.6")) {
+    if (protocols.has("ocpp1.6")) {
       return "ocpp1.6";
     }
 


### PR DESCRIPTION
Most of the WebSocket handshake is already handled by the client we have including key exchange.

We already use [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455)

I mostly just added the protocols to our client and verify the server we connect to supports ocpp1.6.

Also modified the dummy server to make sure the client connecting supports ocpp1.6