### PR TITLE
Electrical Interface

### DIFF
--- a/backend/src/main/java/com/sim_backend/ElectricalTransition.java
+++ b/backend/src/main/java/com/sim_backend/ElectricalTransition.java
@@ -26,10 +26,13 @@ public class ElectricalTransition {
   private long initialChargeTimestamp;
 
   /** Constant representing the number of seconds in an hour. Used for energy calculations. */
-  private static final float SECONDS_PER_HOUR = 3600.0f;
+  private static final long SECONDS_PER_HOUR = 3600;
 
   /** Constant representing the number of milliseconds in an hour. Used for energy calculations. */
   private static final long MILLISECONDS_PER_HOUR = 3600000;
+
+  /** Constant representing the number of milliseconds in a second. Used for energy calculations. */
+  private static final long MILLISECONDS_PER_SECOND = 1000;
 
   /**
    * Calculates and returns the maximum power the charger is capable of providing in kilowatts (kW).
@@ -56,6 +59,12 @@ public class ElectricalTransition {
    * @return the energy consumed since the given interval in kilowatt-hours (kWh).
    */
   public float getEnergyActiveImportInterval(int interval) {
+    long timeChargingSeconds = (System.currentTimeMillis() - this.initialChargeTimestamp) / MILLISECONDS_PER_SECOND;
+
+    // If the requested interval exceeds the actual charging time, adjust accordingly
+    if(timeChargingSeconds < interval) {
+      interval = (int) timeChargingSeconds;
+    }
     return getPowerActiveImport() * ((float) interval / SECONDS_PER_HOUR);
   }
 

--- a/backend/src/main/java/com/sim_backend/ElectricalTransition.java
+++ b/backend/src/main/java/com/sim_backend/ElectricalTransition.java
@@ -59,10 +59,11 @@ public class ElectricalTransition {
    * @return the energy consumed since the given interval in kilowatt-hours (kWh).
    */
   public float getEnergyActiveImportInterval(int interval) {
-    long timeChargingSeconds = (System.currentTimeMillis() - this.initialChargeTimestamp) / MILLISECONDS_PER_SECOND;
+    long timeChargingSeconds =
+        (System.currentTimeMillis() - this.initialChargeTimestamp) / MILLISECONDS_PER_SECOND;
 
     // If the requested interval exceeds the actual charging time, adjust accordingly
-    if(timeChargingSeconds < interval) {
+    if (timeChargingSeconds < interval) {
       interval = (int) timeChargingSeconds;
     }
     return getPowerActiveImport() * ((float) interval / SECONDS_PER_HOUR);

--- a/backend/src/main/java/com/sim_backend/ElectricalTransition.java
+++ b/backend/src/main/java/com/sim_backend/ElectricalTransition.java
@@ -1,0 +1,44 @@
+package com.sim_backend;
+
+import lombok.Getter;
+
+@Getter
+public class ElectricalTransition {
+
+  /** Charger's voltage. Default value of a level 2 charger, 240V. */
+  private int voltage = 240;
+
+  /** Charger's maximum current in amps. Defaults to 40A. */
+  private final int currentOffered = 40;
+
+  /** The actual current drawn from the charger by the EV. */
+  private final int currentImport = 40;
+
+  /** The maximum power the charger is capable of providing in kilowatts (kW).*/
+  private float powerOffered;
+
+  /** The actual power consumed by the charger in kilowatts (kW). Value is not calculated using load balancing. */
+  private float powerActiveImport;
+
+  /** The lifetime energy used by the charger in kilowatt-hours (kWh). */
+  private int lifetimeEnergyUse = 0;
+
+  public ElectricalTransition() {
+    this.powerOffered = (float) (currentOffered * voltage) / 1000;
+    this.powerActiveImport = (float) (currentImport * voltage) / 1000;
+  }
+
+    /**
+     * Retrieves the amount of energy consumed since the specified interval in kilowatt-hours (kWh).
+     *
+     * @param interval the interval in seconds for which the energy usage is being queried
+     * @return the energy consumed since the given interval in kilowatt-hours (kWh).
+     */
+    public float getEnergyActiveImportInterval(int interval) {
+        return this.powerOffered * (interval/3600);
+    }
+
+    public int ChargingTransition() {
+    return 0;
+  }
+}

--- a/backend/src/main/java/com/sim_backend/ElectricalTransition.java
+++ b/backend/src/main/java/com/sim_backend/ElectricalTransition.java
@@ -1,8 +1,7 @@
 package com.sim_backend;
 
-import com.sim_backend.state.IllegalStateException;
 import com.sim_backend.state.SimulatorState;
-import com.sim_backend.state.SimulatorStateMachine;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
@@ -10,26 +9,18 @@ import lombok.NoArgsConstructor;
  * power, voltage, current, and energy consumed. It tracks the charging state and calculates the
  * power usage and energy consumption in kilowatt-hours (kWh).
  */
+@Getter
 @NoArgsConstructor
 public class ElectricalTransition {
 
-  /** The charger's voltage in volts. */
+  /** The charger's voltage in volts. Defaults to 240 volts */
   private int voltage;
 
-  /** The maximum current offered by the charger in amps. */
+  /** The maximum current offered by the charger in amps. Defaults to 40 amps */
   private int currentOffered;
 
-  /** The actual current drawn from the charger by the EV. */
+  /** The actual current drawn from the charger by the EV. Defaults to 40 amps */
   private int currentImport;
-
-  /** The maximum power the charger is capable of providing in kilowatts (kW). */
-  private float powerOffered;
-
-  /**
-   * The actual power consumed by the charger in kilowatts (kW). Value is not calculated using load
-   * balancing.
-   */
-  private float powerActiveImport;
 
   /** A timestamp of when charging first started. */
   private long initialChargeTimestamp;
@@ -41,13 +32,31 @@ public class ElectricalTransition {
   private static final long MILLISECONDS_PER_HOUR = 3600000;
 
   /**
+   * Calculates and returns the maximum power the charger is capable of providing in kilowatts (kW).
+   *
+   * @return the maximum power offered in kilowatts (kW).
+   */
+  public float getPowerOffered() {
+    return (float) (currentOffered * voltage) / 1000;
+  }
+
+  /**
+   * Calculates and returns the actual power consumed by the charger in kilowatts (kW).
+   *
+   * @return the actual power consumed in kilowatts (kW).
+   */
+  public float getPowerActiveImport() {
+    return (float) (currentImport * voltage) / 1000;
+  }
+
+  /**
    * Retrieves the amount of energy consumed since the specified interval in kilowatt-hours (kWh).
    *
    * @param interval the interval in seconds for which the energy usage is being queried
    * @return the energy consumed since the given interval in kilowatt-hours (kWh).
    */
   public float getEnergyActiveImportInterval(int interval) {
-    return this.powerOffered * ((float) interval / SECONDS_PER_HOUR);
+    return getPowerActiveImport() * ((float) interval / SECONDS_PER_HOUR);
   }
 
   /**
@@ -57,35 +66,33 @@ public class ElectricalTransition {
    */
   public float getEnergyActiveImportRegister() {
     long timeCharging = System.currentTimeMillis() - this.initialChargeTimestamp;
-    return this.powerOffered * ((float) timeCharging / MILLISECONDS_PER_HOUR);
+    return getPowerActiveImport() * ((float) timeCharging / MILLISECONDS_PER_HOUR);
   }
 
   /**
-   * Initiates the charging transition, setting the initial charging parameters such as voltage,
-   * current, and power. The function also checks if the state machine is in the correct state
-   * (Charging) before applying the transition.
+   * Updates the electrical values based on the given simulator state. If the state is not Charging,
+   * all electrical values are reset to zero. Otherwise, when in the Charging state, the voltage is
+   * set to 240V, and the current offered and imported are both set to 40A. The initial charge
+   * timestamp is also updated to the current system time.
    *
-   * @param stateMachine The state machine controlling the charging process.
-   * @throws IllegalStateException If the current state is not 'Charging', an exception is thrown.
+   * @param state the current state of the charger
    */
-  public void ChargingTransition(SimulatorStateMachine stateMachine) {
+  public void transition(SimulatorState state) {
 
-    if (stateMachine.getCurrentState() != SimulatorState.Charging) {
-      throw new IllegalStateException(
-          "Charging transition triggered during incorrect state: "
-              + stateMachine.getCurrentState());
+    // Whenever we aren't charging, zero all the electrical values.
+    if (state != SimulatorState.Charging) {
+      this.voltage = 0;
+      this.currentOffered = 0;
+      this.currentImport = 0;
+      this.initialChargeTimestamp = 0;
     }
 
-    // Set the charger's voltage and current parameters for the transition.
-    this.voltage = 240;
-    this.currentOffered = 40;
-    this.currentImport = 40;
-
-    // Calculate the power offered and the active power import in kilowatts.
-    this.powerOffered = (float) (currentOffered * voltage) / 1000;
-    this.powerActiveImport = (float) (currentImport * voltage) / 1000;
-
-    // Record the timestamp when the charging starts.
-    initialChargeTimestamp = System.currentTimeMillis();
+    // State is charging, proceed to set electrical values
+    else {
+      this.voltage = 240;
+      this.currentOffered = 40;
+      this.currentImport = 40;
+      this.initialChargeTimestamp = System.currentTimeMillis();
+    }
   }
 }

--- a/backend/src/main/java/com/sim_backend/ElectricalTransition.java
+++ b/backend/src/main/java/com/sim_backend/ElectricalTransition.java
@@ -1,6 +1,7 @@
 package com.sim_backend;
 
 import com.sim_backend.state.SimulatorState;
+import com.sim_backend.state.StateObserver;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor
-public class ElectricalTransition {
+public class ElectricalTransition implements StateObserver {
 
   /** The charger's voltage in volts. */
   private int voltage;
@@ -85,12 +86,13 @@ public class ElectricalTransition {
    * set to 240V, and the current offered and imported are both set to 40A. The initial charge
    * timestamp is also updated to the current system time.
    *
-   * @param state the current state of the charger
+   * @param simulatorState is the current simulator state
    */
-  public void transition(SimulatorState state) {
+  @Override
+  public void onStateChanged(SimulatorState simulatorState) {
 
     // Whenever we aren't charging, zero all the electrical values.
-    if (state != SimulatorState.Charging) {
+    if (simulatorState != SimulatorState.Charging) {
       this.voltage = 0;
       this.currentOffered = 0;
       this.currentImport = 0;

--- a/backend/src/main/java/com/sim_backend/ElectricalTransition.java
+++ b/backend/src/main/java/com/sim_backend/ElectricalTransition.java
@@ -13,13 +13,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ElectricalTransition {
 
-  /** The charger's voltage in volts. Defaults to 240 volts */
+  /** The charger's voltage in volts. */
   private int voltage;
 
-  /** The maximum current offered by the charger in amps. Defaults to 40 amps */
+  /** The maximum current offered by the charger in amps. */
   private int currentOffered;
 
-  /** The actual current drawn from the charger by the EV. Defaults to 40 amps */
+  /** The actual current drawn from the charger by the EV. */
   private int currentImport;
 
   /** A timestamp of when charging first started. */

--- a/backend/src/main/java/com/sim_backend/ElectricalTransition.java
+++ b/backend/src/main/java/com/sim_backend/ElectricalTransition.java
@@ -5,14 +5,19 @@ import com.sim_backend.state.SimulatorState;
 import com.sim_backend.state.SimulatorStateMachine;
 import lombok.NoArgsConstructor;
 
+/**
+ * This class represents the electrical transition of a charging process, including the charging
+ * power, voltage, current, and energy consumed. It tracks the charging state and calculates the
+ * power usage and energy consumption in kilowatt-hours (kWh).
+ */
 @NoArgsConstructor
 public class ElectricalTransition {
 
-  /** Charger's voltage.*/
+  /** The charger's voltage in volts. */
   private int voltage;
 
-  /** Charger's maximum current in amps.*/
-  private  int currentOffered;
+  /** The maximum current offered by the charger in amps. */
+  private int currentOffered;
 
   /** The actual current drawn from the charger by the EV. */
   private int currentImport;
@@ -26,19 +31,13 @@ public class ElectricalTransition {
    */
   private float powerActiveImport;
 
-  /**
-   * A timestamp of when charging first occurs
-   */
+  /** A timestamp of when charging first started. */
   private long initialChargeTimestamp;
 
-  /**
-   * Amount of seconds per hour. Used for calculations.
-   */
+  /** Constant representing the number of seconds in an hour. Used for energy calculations. */
   private static final float SECONDS_PER_HOUR = 3600.0f;
 
-  /**
-   * Amount of milliseconds per hour. Used for calculations.
-   */
+  /** Constant representing the number of milliseconds in an hour. Used for energy calculations. */
   private static final long MILLISECONDS_PER_HOUR = 3600000;
 
   /**
@@ -56,22 +55,37 @@ public class ElectricalTransition {
    *
    * @return the lifetime energy consumed in kilowatt-hours (kWh).
    */
-  public float getEnergyActiveImportRegister(){
+  public float getEnergyActiveImportRegister() {
     long timeCharging = System.currentTimeMillis() - this.initialChargeTimestamp;
-    return this.powerOffered * ((float) timeCharging /MILLISECONDS_PER_HOUR);
+    return this.powerOffered * ((float) timeCharging / MILLISECONDS_PER_HOUR);
   }
 
+  /**
+   * Initiates the charging transition, setting the initial charging parameters such as voltage,
+   * current, and power. The function also checks if the state machine is in the correct state
+   * (Charging) before applying the transition.
+   *
+   * @param stateMachine The state machine controlling the charging process.
+   * @throws IllegalStateException If the current state is not 'Charging', an exception is thrown.
+   */
   public void ChargingTransition(SimulatorStateMachine stateMachine) {
 
-    if(stateMachine.getCurrentState() != SimulatorState.Charging){
-      throw new IllegalStateException("Charging transition triggered during incorrect state: " + stateMachine.getCurrentState());
+    if (stateMachine.getCurrentState() != SimulatorState.Charging) {
+      throw new IllegalStateException(
+          "Charging transition triggered during incorrect state: "
+              + stateMachine.getCurrentState());
     }
 
+    // Set the charger's voltage and current parameters for the transition.
     this.voltage = 240;
     this.currentOffered = 40;
     this.currentImport = 40;
-    this.powerOffered = (float) (currentOffered * voltage) /1000;
-    this.powerActiveImport = (float) (currentImport * voltage) /1000;
+
+    // Calculate the power offered and the active power import in kilowatts.
+    this.powerOffered = (float) (currentOffered * voltage) / 1000;
+    this.powerActiveImport = (float) (currentImport * voltage) / 1000;
+
+    // Record the timestamp when the charging starts.
     initialChargeTimestamp = System.currentTimeMillis();
   }
 }

--- a/backend/src/test/java/com/sim_backend/ElectricalTransitionTest.java
+++ b/backend/src/test/java/com/sim_backend/ElectricalTransitionTest.java
@@ -1,0 +1,65 @@
+package com.sim_backend;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sim_backend.state.SimulatorState;
+import org.junit.jupiter.api.Test;
+
+public class ElectricalTransitionTest {
+
+  @Test
+  public void InitializedTest() {
+    ElectricalTransition et = new ElectricalTransition();
+
+    assert (et.getPowerActiveImport() == 0);
+    assert (et.getPowerOffered() == 0);
+    assert (et.getCurrentImport() == 0);
+    assert (et.getCurrentOffered() == 0);
+    assert (et.getVoltage() == 0);
+    assert (et.getEnergyActiveImportRegister() == 0);
+    assert (et.getEnergyActiveImportInterval(100)
+        == 0); // Should be 0 if other electrical values are 0.
+    assert (et.getInitialChargeTimestamp() == 0);
+  }
+
+  @Test
+  public void ChargingStateTest() {
+
+    ElectricalTransition et = new ElectricalTransition();
+    long beforeCreation = System.currentTimeMillis();
+    et.onStateChanged(SimulatorState.Charging);
+    long afterCreation = System.currentTimeMillis();
+
+    assert (et.getVoltage() == 240);
+    assert (et.getCurrentOffered() == 40);
+    assert (et.getCurrentImport() == 40);
+
+    // Get the timestamp from the object
+    long objectTimestamp = et.getInitialChargeTimestamp();
+
+    // Allow a small tolerance for the timestamp (3 seconds)
+    long toleranceInMillis = 3000;
+
+    assertTrue(
+        objectTimestamp >= beforeCreation - toleranceInMillis
+            && objectTimestamp <= afterCreation + toleranceInMillis,
+        "Timestamp is not within the acceptable range.");
+  }
+
+  @Test
+  public void ChargingStateIntoNonCharging() {
+
+    ElectricalTransition et = new ElectricalTransition();
+    et.onStateChanged(SimulatorState.Charging);
+    et.onStateChanged((SimulatorState.PoweredOff));
+    assert (et.getPowerActiveImport() == 0);
+    assert (et.getPowerOffered() == 0);
+    assert (et.getCurrentImport() == 0);
+    assert (et.getCurrentOffered() == 0);
+    assert (et.getVoltage() == 0);
+    assert (et.getEnergyActiveImportRegister() == 0);
+    assert (et.getEnergyActiveImportInterval(100)
+        == 0); // Should be 0 if other electrical values are 0.
+    assert (et.getInitialChargeTimestamp() == 0);
+  }
+}


### PR DESCRIPTION
Creates an electrical interface that currently just manages electrical values when changing state.
All values are initialized to 0 since we begin not charging and are updated once charging begins.

One question I had was if both getEnergy() methods needs to take into account the charging not being fully active from the initial timestamp. Maybe this will be implemented later. For now, it assumes that once charging starts, it remains charging with no interruptions. 