### PR TITLE
Update dummy server to specify message sequences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ docker_debug:
 	DEBUG_STAGE=suspend-debug docker-compose --profile core up --build
 
 integration_test:
-	DEBUG_STAGE=run-debug docker-compose --env-file .env.internal --profile integration-test up --build
+	docker-compose --env-file .env.internal --profile integration-test up --build
 
 dummy_server:
-	docker compose --profile core --profile dummy-server up --build
+	NORMAL_MODE=enabled docker compose --profile core --profile dummy-server up --build
 
 dummy_server_debug:
-	DEBUG_STAGE=suspend-debug docker compose --profile core --profile dummy-server up --build
+	NORMAL_MODE=enabled DEBUG_STAGE=suspend-debug docker compose --profile core --profile dummy-server up --build
 
 build_backend:
 	cd ./backend && mvn spotless:apply && mvn clean && mvn package

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - integration-test
     environment:
       - NODE_ENV=production
+      - NORMAL_MODE=${NORMAL_MODE}
     networks:
       - core-network
 

--- a/dummy_server/ConfigurationHttpServer.js
+++ b/dummy_server/ConfigurationHttpServer.js
@@ -1,0 +1,72 @@
+const express = require("express");
+const globals = require('./Global');
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+const receivedMessages = [];
+let responseData = null;  // Store the response content
+
+// Endpoint to retrieve received WebSocket messages
+app.get("/api/messageLength", (req, res) => {
+  res.json({ message: receivedMessages.length });
+});
+
+// Endpoint to retrieve next received WebSocket message
+app.get("/api/messages", (req, res) => {
+  res.json({ message: receivedMessages.shift() });
+});
+
+// Endpoint to delete all received WebSocket messages
+app.delete("/api/messages", (req, res) => {
+  receivedMessages.length = 0;
+  res.json({ message: "All messages deleted successfully" });
+});
+
+// Endpoint to upload a response file content
+app.post("/api/uploadResponse", (req, res) => {
+  const responseData = req.body;
+
+  if (!responseData) {
+    return res.status(400).json({ error: "No response data received" });
+  }
+
+  /* Given the following example input:
+  {
+    "a3":{"key":"value",...},
+    "b4":{"key":"value",...}...
+  }
+
+  Generate the following response list:
+  [3 * {"key":"value",...}, 4 * {"key":"value",...}, ...]
+  */
+  Object.entries(responseData).forEach(([key, response]) => {
+    const count = parseInt(key.replace(/^\D+/, ""), 10); // Parse out the number in the key
+    for (let i = 0; i < count; i++) {
+      globals.addResponseData(response);
+    }
+  });
+
+  console.log("Configured response(s):", globals.getResponseData());
+
+  res.json({ message: "Response file content stored successfully" });
+});
+
+// Endpoint to reset response data to null
+app.post("/api/resetResponseData", (req, res) => {
+  globals.setResponseData([]);
+  
+  console.log("Response data has been reset to null");
+  res.json({ message: "Response data has been reset to null" });
+});
+
+// Start the HTTP server
+const startHttpServer = (port = 9001) => {
+  const server = app.listen(port, () => {
+    console.log(`HTTP server running on port ${port}`);
+  });
+
+  return { server, receivedMessages, responseData };
+};
+
+module.exports = { startHttpServer, receivedMessages };

--- a/dummy_server/DummyServer.js
+++ b/dummy_server/DummyServer.js
@@ -1,65 +1,23 @@
-const express = require("express");
-const { WebSocketServer } = require("ws");
+const { startHttpServer } = require("./ConfigurationHttpServer");
+const { startWebSocketServer } = require("./WebSocketServer");
 
-const app = express();
-app.use(express.json());
+const httpPort = 9001;
+const wsPort = 9000;
 
-const receivedMessages = [];
+const { server: httpServer, receivedMessages } = startHttpServer(httpPort);
+const webSocketServer = startWebSocketServer(wsPort, receivedMessages);
 
-// WebSocket server
-const wss = new WebSocketServer({
-  port: 9000,
-  handleProtocols: (protocols, request) => {
-    if (protocols.has("ocpp1.6")) {
-      return "ocpp1.6";
-    }
-
-    console.error("No supported subprotocol found");
-    return false;
-  },
-});
-
-wss.on("connection", (ws) => {
-  console.log("WebSocket connection established");
-
-  ws.on("message", (message) => {
-    console.log("Message received:", message.toString());
-    receivedMessages.push(message.toString());
-  });
-
-  ws.on("close", () => {
-    console.log("WebSocket connection closed");
-  });
-});
-
-// HTTP API to retrieve received WebSocket messages
-app.get("/api/messages", (req, res) => {
-  res.json({ messages: receivedMessages });
-});
-
-// HTTP API to delete all received WebSocket messages
-app.delete("/api/messages", (req, res) => {
-  receivedMessages.length = 0;
-  res.json({ message: "All messages deleted successfully" });
-});
-
-// Start the HTTP server
-const port = 9001;
-const server = app.listen(port, () => {
-  console.log(`HTTP server running on port ${port}`);
-});
-
-// Shutdown manually as it is much faster
+// Graceful shutdown
 const shutdown = () => {
   console.log("Shutting down...");
 
   // Close WebSocket server
-  wss.close(() => {
+  webSocketServer.close(() => {
     console.log("WebSocket server closed");
   });
 
   // Close HTTP server
-  server.close(() => {
+  httpServer.close(() => {
     console.log("HTTP server closed");
     process.exit(0);
   });

--- a/dummy_server/Global.js
+++ b/dummy_server/Global.js
@@ -1,0 +1,19 @@
+let responseList = [];
+
+module.exports = {
+  addResponseData(response) {
+    responseList.push(response);
+  },
+  setResponseData(newResponseList) {
+    responseList = [];
+    newResponseList.forEach(response => {
+      responseList.push(response);
+    });
+  },
+  shiftResponseData() {
+    return responseList.shift();
+  },
+  getResponseData() {
+    return responseList;
+  },
+};

--- a/dummy_server/NormalModeResponses.json
+++ b/dummy_server/NormalModeResponses.json
@@ -1,0 +1,7 @@
+{
+    "BootNotification":{"status":"Accepted", "currentTime":"X", "interval":60},
+    "Heartbeat":{"currentTime":"X"},
+    "Authorize":{"idTagInfo":{"status":"Accepted"}},
+    "StartTransaction":{"idTagInfo":{"status":"Accepted"}, "transactionId":5},
+    "StopTransaction":{"idTagInfo":{"status":"Accepted"}}
+}

--- a/dummy_server/WebSocketServer.js
+++ b/dummy_server/WebSocketServer.js
@@ -1,0 +1,84 @@
+const { WebSocketServer } = require("ws");
+const globals = require('./Global');
+const fs = require("fs");
+
+const startWebSocketServer = (port = 9000, receivedMessages) => {
+  // Load predefined responses if its environment variable is set
+  let normalModeResponses = null;
+  if (process.env.NORMAL_MODE) {
+    try {
+      const filePath = "NormalModeResponses.json";
+      normalModeResponses = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      console.log("Normal mode responses loaded");
+    } catch (err) {
+      console.error("Failed to load NormalModeResponses.json:", err);
+    }
+  }
+
+  const wss = new WebSocketServer({
+    port: port,
+    handleProtocols: (protocols, request) => {
+      if (protocols.has("ocpp1.6")) {
+        return "ocpp1.6";
+      }
+  
+      console.error("No supported subprotocol found");
+      return false;
+    },
+  });
+
+  wss.on("connection", (ws) => {
+    console.log("WebSocket connection established");
+
+    ws.on('message', async (message) => {
+      console.log('Message received:', message.toString());
+      const parsedMessage = JSON.parse(message.toString());
+      receivedMessages.push(parsedMessage);
+    
+      const messageId = parsedMessage[1];
+      const action = parsedMessage[2];
+      let responseData;
+
+      // Helper function for adding a delay
+      const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+      // If we have loaded normal mode responses and there's a match, use it
+      if (normalModeResponses && normalModeResponses[action]) {
+        await delay(1000);  // Delay for 1 second to simulate network latency
+        responseData = normalModeResponses[action];
+      } else {
+        responseData = globals.shiftResponseData();
+      }
+    
+      if (responseData) {
+        const updatedResponseData = { ...responseData };
+    
+        if ('currentTime' in updatedResponseData) {
+          // Set the current time in UTC format
+          updatedResponseData.currentTime = new Date().toISOString();
+        }
+    
+        // Construct the response message
+        const responseMessage = [
+          3, // Message type for response
+          messageId,
+          updatedResponseData,
+        ];
+    
+        // Send the response back
+        ws.send(JSON.stringify(responseMessage));
+        console.log("Response sent:", JSON.stringify(responseMessage, null, 2));
+      }
+    });
+    
+
+    ws.on("close", () => {
+      console.log("WebSocket connection closed");
+    });
+  });
+
+  console.log(`WebSocket server running on port ${port}`);
+  return wss;
+};
+
+module.exports = { startWebSocketServer };


### PR DESCRIPTION
This is a rework of the dummy server used in integration testing. It splits the `DummyServer.js` monolith into separate files for its WebSocket server and HTTP server. The dummy server can be ran, along with the frontend/backend, using `make dummy_server`.

Notable features:
- Normal mode: when the environment variable `NORMAL_MODE` exists, the dummy server will automatically respond to incoming OCPP messages. This makes some informal testing and demoing more simple. These predefined responses are in `dummy_server/NormalModeResponses.json`
- Response files: if a Json file is sent to `dummy-server/api/uploadResponse`, the WebSocket server will use it to determine what responses to send to a sequence of messages. Example:
>This input
>{
>   "a1":{"status":"Accepted", "currentTime":"X", "interval":5},
>    "b5":{"currentTime":"X"}
>}
>
>  Generate the following sequence of responses:
>  [3, "<message response id here>",{"status":"Accepted", "currentTime":"<timestamp added here>", "interval":5}]
>  5x  [3, "<message response id here>",{"currentTime":"<timestamp added here>"}]


The StatelessMessages test is not updated for this rework, and gets deprecated in the other integration testing pr. The reason for this is that the "Send Messages" button will very likely receive changes in the near future.