### PR TITLE
Field validity enforcement

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -97,6 +97,23 @@
             <artifactId>jakarta.validation-api</artifactId>
             <version>3.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- ADD NEW DEPENDENCIES HERE -->
         <!-- <dependency>
             <groupId>group.id.here</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -92,12 +92,18 @@
             <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <!-- ADD NEW DEPENDENCIES HERE -->
         <!-- <dependency>
             <groupId>group.id.here</groupId>
             <artifactId>artifact-id-here</artifactId>
             <version>version-here</version>
         </dependency> -->
+
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
@@ -13,10 +13,7 @@ import com.google.gson.JsonParser;
 import com.sim_backend.websockets.OCPPWebSocketClient;
 import com.sim_backend.websockets.enums.ChargePointErrorCode;
 import com.sim_backend.websockets.enums.ChargePointStatus;
-import com.sim_backend.websockets.messages.Authorize;
-import com.sim_backend.websockets.messages.BootNotification;
-import com.sim_backend.websockets.messages.Heartbeat;
-import com.sim_backend.websockets.messages.StatusNotification;
+import com.sim_backend.websockets.messages.*;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import java.net.URI;
@@ -41,6 +38,9 @@ public class MessageController extends ControllerBase {
 
   public void authorize(Context ctx) {
     Authorize msg = new Authorize();
+    if (!MessageValidator.isValid(msg)) {
+      throw new IllegalArgumentException(MessageValidator.log_message(msg));
+    }
     webSocketClient.pushMessage(msg);
     ctx.result("OK");
   }
@@ -57,12 +57,20 @@ public class MessageController extends ControllerBase {
             "IMSI",
             "Meter Type",
             "Meter S/N");
+
+    if (!MessageValidator.isValid(msg)) {
+      throw new IllegalArgumentException(MessageValidator.log_message(msg));
+    }
+
     webSocketClient.pushMessage(msg);
     ctx.result("OK");
   }
 
   public void heartbeat(Context ctx) {
     Heartbeat msg = new Heartbeat();
+    if (!MessageValidator.isValid(msg)) {
+      throw new IllegalArgumentException(MessageValidator.log_message(msg));
+    }
     webSocketClient.pushMessage(msg);
     ctx.result("OK");
   }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/Authorize.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/Authorize.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -20,6 +22,8 @@ import lombok.Setter;
 public class Authorize extends OCPPMessageRequest {
 
   @SerializedName("idTag")
+  @NotBlank(message = "Authorize idTag must not be blank")
+  @Size(max = 20, message = "Authorize idTag must be at most 20 characters")
   private String idTag;
 
   // Constructor
@@ -34,10 +38,8 @@ public class Authorize extends OCPPMessageRequest {
     this.idTag = generateIdTag();
   }
 
-  public String generateIdTag() {
-    // Generate a UUID
-    String uuid = UUID.randomUUID().toString();
-    // Remove hyphens and truncate to 20 characters
-    return uuid.replace("-", "").substring(0, 20);
+  private String generateIdTag() {
+    // Generate a UUID, remove hyphens, and truncate to 20 characters
+    return UUID.randomUUID().toString().replace("-", "").substring(0, 20);
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
@@ -5,6 +5,7 @@ import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.enums.AuthorizationStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class AuthorizeResponse extends OCPPMessageResponse {
   @AllArgsConstructor
   public static class IdTagInfo {
 
+    @NotBlank(message = "AuthorizeResponse status is required and cannot be blank")
     @SerializedName("status")
     private AuthorizationStatus status; // One of: Accepted, Blocked, Expired, Invalid, ConcurrentTx
   }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
@@ -9,6 +9,8 @@ import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.constants.BootNotificationConstants;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -21,38 +23,51 @@ import lombok.Getter;
 public final class BootNotification extends OCPPMessageRequest {
 
   /** The Charge Point's Vendor. */
+  @NotBlank(message = "BootNotification chargePointVendor is required")
+  @Size(max = 20, message = "BootNotification chargePointVendor must not exceed 20 characters")
   @SerializedName("chargePointVendor")
   private final String chargePointVendor;
 
   /** The Charge Point's Model. */
+  @NotBlank(message = "BootNotification chargePointModel is required")
+  @Size(max = 20, message = "BootNotification chargePointModel must not exceed 20 characters")
   @SerializedName("chargePointModel")
   private final String chargePointModel;
 
   /** The Charge Point's Serial Number. */
+  @Size(
+      max = 25,
+      message = "BootNotification chargePointSerialNumber must not exceed 25 characters")
   @SerializedName("chargePointSerialNumber")
   private final String chargePointSerialNumber;
 
   /** The Charge Box's Serial Number. */
+  @Size(max = 25, message = "BootNotification chargeBoxSerialNumber must not exceed 25 characters")
   @SerializedName("chargeBoxSerialNumber")
   private final String chargeBoxSerialNumber;
 
   /** Firmware Version. */
+  @Size(max = 50, message = "BootNotification firmwareVersion must not exceed 50 characters")
   @SerializedName("firmwareVersion")
   private final String firmwareVersion;
 
   /** ICCID (Integrated Circuit Card Identifier) . */
+  @Size(max = 20, message = "BootNotification ICCID must not exceed 20 characters")
   @SerializedName("iccid")
   private final String iccid;
 
   /** IMSI (International Mobile Subscriber Identity). */
+  @Size(max = 20, message = "BootNotification IMSI must not exceed 20 characters")
   @SerializedName("imsi")
   private final String imsi;
 
   /** Meter Type. */
+  @Size(max = 25, message = "BootNotification meterType must not exceed 25 characters")
   @SerializedName("meterType")
   private final String meterType;
 
   /** Meter Serial Number. */
+  @Size(max = 25, message = "BootNotification meterSerialNumber must not exceed 25 characters")
   @SerializedName("meterSerialNumber")
   private final String meterSerialNumber;
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
@@ -5,6 +5,7 @@ import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.enums.RegistrationStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
+import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -24,14 +25,20 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = true)
 public class BootNotificationResponse extends OCPPMessageResponse {
 
+  /** Status of the BootNotification (Accepted, Pending, Rejected). Required. */
+  @NotNull(message = "Registration status is required")
   @SerializedName("status")
-  private RegistrationStatus status; // Status of the BootNotification (Accepted, Rejected)
+  private RegistrationStatus status;
 
+  /** Current time in ISO 8601 format. Required. */
+  @NotNull(message = "Current time is required")
   @SerializedName("currentTime")
-  private ZonedDateTime currentTime; // Current time in ISO 8601 format
+  private ZonedDateTime currentTime;
 
+  /** Interval (time in seconds) for next BootNotification. Must be positive. */
+  @NotNull(message = "Interval is required")
   @SerializedName("interval")
-  private int interval; // Interval (time in seconds) for next BootNotification
+  private int interval;
 
   public BootNotificationResponse(String status, ZonedDateTime currentTime, int interval) {
     this.status = RegistrationStatus.fromString(status);

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
@@ -26,17 +26,17 @@ import lombok.Setter;
 public class BootNotificationResponse extends OCPPMessageResponse {
 
   /** Status of the BootNotification (Accepted, Pending, Rejected). Required. */
-  @NotNull(message = "Registration status is required")
+  @NotNull(message = "BootNotificationResponse Registration status is required")
   @SerializedName("status")
   private RegistrationStatus status;
 
   /** Current time in ISO 8601 format. Required. */
-  @NotNull(message = "Current time is required")
+  @NotNull(message = "BootNotificationResponse Current time is required")
   @SerializedName("currentTime")
   private ZonedDateTime currentTime;
 
   /** Interval (time in seconds) for next BootNotification. Must be positive. */
-  @NotNull(message = "Interval is required")
+  @NotNull(message = "BootNotificationResponse Interval is required")
   @SerializedName("interval")
   private int interval;
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/HeartbeatResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/HeartbeatResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
+import jakarta.validation.constraints.NotBlank;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ import lombok.Getter;
 public final class HeartbeatResponse extends OCPPMessageResponse {
 
   /** The Heartbeat's time. */
+  @NotBlank(message = "HeartbeatResponse current time is required")
   @SerializedName("currentTime")
   private final ZonedDateTime currentTime;
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/MessageValidator.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/MessageValidator.java
@@ -1,3 +1,52 @@
 package com.sim_backend.websockets.messages;
 
-public class MessageValidator {}
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for validating objects using Jakarta Bean Validation (JSR-380).
+ * It provides methods to check whether an object is valid and retrieve validation messages.
+ */
+public class MessageValidator{
+
+    private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+
+    private static final Validator validator = factory.getValidator();
+
+    /**
+     * Validates the given object and returns validation messages if any constraint violations occur.
+     *
+     * @param object The object to be validated.
+     * @param <T>    The type of the object.
+     * @return A string containing validation messages if invalid, or "Valid" if there are no violations.
+     */
+    public static <T> String validate(T object) {
+        // Get the set of constraint violations
+        Set<ConstraintViolation<T>> violations = validator.validate(object);
+
+        // If there are no violations, return "Valid"
+        if (violations.isEmpty()) {
+            return "Valid";
+        }
+
+        // Convert validation errors into a readable string format
+        return violations.stream()
+                .map(v -> v.getPropertyPath() + " " + v.getMessage()) // Example: "transactionId must not be null"
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Checks if the given object is valid.
+     *
+     * @param object The object to be validated.
+     * @param <T>    The type of the object.
+     * @return true if the object is valid, false otherwise.
+     */
+    public static <T> boolean isValid(T object) {
+        return validator.validate(object).isEmpty(); // Returns true if no violations
+    }
+}

--- a/backend/src/main/java/com/sim_backend/websockets/messages/MessageValidator.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/MessageValidator.java
@@ -1,52 +1,58 @@
 package com.sim_backend.websockets.messages;
 
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
-import jakarta.validation.ConstraintViolation;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Utility class for validating objects using Jakarta Bean Validation (JSR-380).
- * It provides methods to check whether an object is valid and retrieve validation messages.
+ * Utility class for validating objects using Jakarta Bean Validation (JSR-380). It provides methods
+ * to check whether an object is valid and retrieve validation messages.
  */
-public class MessageValidator{
+public class MessageValidator {
 
-    private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+  private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 
-    private static final Validator validator = factory.getValidator();
+  private static final Validator validator = factory.getValidator();
 
-    /**
-     * Validates the given object and returns validation messages if any constraint violations occur.
-     *
-     * @param object The object to be validated.
-     * @param <T>    The type of the object.
-     * @return A string containing validation messages if invalid, or "Valid" if there are no violations.
-     */
-    public static <T> String validate(T object) {
-        // Get the set of constraint violations
-        Set<ConstraintViolation<T>> violations = validator.validate(object);
+  /**
+   * Validates the given object and returns validation messages if any constraint violations occur.
+   * Useful for logging constraint errors
+   *
+   * @param object The object to be validated.
+   * @param <T> The type of the object.
+   * @return A string containing validation messages if invalid, or "Valid" if there are no
+   *     violations.
+   */
+  public static <T> String log_message(T object) {
+    // Get the set of constraint violations
+    Set<ConstraintViolation<T>> violations = validator.validate(object);
 
-        // If there are no violations, return "Valid"
-        if (violations.isEmpty()) {
-            return "Valid";
-        }
-
-        // Convert validation errors into a readable string format
-        return violations.stream()
-                .map(v -> v.getPropertyPath() + " " + v.getMessage()) // Example: "transactionId must not be null"
-                .collect(Collectors.joining(", "));
+    // If there are no violations, return "Valid"
+    if (violations.isEmpty()) {
+      return "Valid";
     }
 
-    /**
-     * Checks if the given object is valid.
-     *
-     * @param object The object to be validated.
-     * @param <T>    The type of the object.
-     * @return true if the object is valid, false otherwise.
-     */
-    public static <T> boolean isValid(T object) {
-        return validator.validate(object).isEmpty(); // Returns true if no violations
-    }
+    // Convert validation errors into a readable string format
+    return violations.stream()
+        .map(
+            v ->
+                v.getPropertyPath()
+                    + " "
+                    + v.getMessage()) // Example: "transactionId must not be null"
+        .collect(Collectors.joining(", "));
+  }
+
+  /**
+   * Checks if the given object is valid.
+   *
+   * @param object The object to be validated.
+   * @param <T> The type of the object.
+   * @return true if the object is valid, false otherwise.
+   */
+  public static <T> boolean isValid(T object) {
+    return validator.validate(object).isEmpty(); // Returns true if no violations
+  }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StartTransaction.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StartTransaction.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,16 +18,20 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = true)
 @OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_REQUEST, messageName = "StartTransaction")
 public class StartTransaction extends OCPPMessageRequest {
+
   @SerializedName("connectorId")
   private int connectorId;
 
   @SerializedName("idTag")
+  @NotBlank(message = "StartTransaction idTag is required and cannot be blank")
+  @Size(max = 20, message = "StartTransaction idTag must not exceed 20 characters")
   private String idTag;
 
   @SerializedName("meterStart")
   private int meterStart;
 
   @SerializedName("timestamp")
+  @NotBlank(message = "StartTransaction Timestamp is required and cannot be blank")
   private String timestamp;
 
   // Constructor

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StartTransactionResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StartTransactionResponse.java
@@ -5,6 +5,7 @@ import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.enums.AuthorizationStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -30,6 +31,7 @@ public class StartTransactionResponse extends OCPPMessageResponse {
   @AllArgsConstructor
   public static class IdTagInfo {
 
+    @NotBlank(message = "StartTransactionResponse Status is required and cannot be blank")
     @SerializedName("status")
     private AuthorizationStatus status; // Status of the idTag (e.g., Accepted, Blocked, etc.).
   }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StatusNotification.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StatusNotification.java
@@ -1,7 +1,3 @@
-/**
- * Represents an OCPP 1.6 Status Notification Request sent by a Charge Point to provide its
- * identity, configuration, and status to the Central System.
- */
 package com.sim_backend.websockets.messages;
 
 import com.google.gson.annotations.SerializedName;
@@ -10,6 +6,9 @@ import com.sim_backend.websockets.enums.ChargePointErrorCode;
 import com.sim_backend.websockets.enums.ChargePointStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.OffsetDateTime;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -20,24 +19,30 @@ import lombok.Getter;
 @OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_REQUEST, messageName = "StatusNotification")
 public final class StatusNotification extends OCPPMessageRequest {
 
+  @NotNull(message = "StatusNotification connectorId is required")
   @SerializedName("connectorId")
   private int connectorId;
 
+  @NotBlank(message = "Status Notification Error code is required and cannot be blank")
   @SerializedName("errorCode")
   private ChargePointErrorCode errorCode;
 
+  @Size(max = 50, message = "StatusNotification Info must not exceed 50 characters")
   @SerializedName("info")
   private String info;
 
+  @NotBlank(message = "StatusNotification Status is required and cannot be blank")
   @SerializedName("status")
   private ChargePointStatus status;
 
   @SerializedName("timestamp")
   private OffsetDateTime timestamp;
 
+  @Size(max = 255, message = "StatusNotification Vendor ID must not exceed 255 characters")
   @SerializedName("vendorId")
   private String vendorId;
 
+  @Size(max = 50, message = "StatusNotification Vendor error code must not exceed 50 characters")
   @SerializedName("vendorErrorCode")
   private String vendorErrorCode;
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StopTransaction.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StopTransaction.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageRequest;
+import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -19,12 +20,15 @@ public class StopTransaction extends OCPPMessageRequest {
   /*
    * TODO : transactionData needs to be implemented
    */
+  @NotNull(message = "StopTransaction transactionId is required")
   @SerializedName("transactionId")
   private int transactionId;
 
+  @NotNull(message = "StopTransaction meterStop is required")
   @SerializedName("meterStop")
   private int meterStop;
 
+  @NotNull(message = "StopTransaction timestamp is required")
   @SerializedName("timestamp")
   private String timestamp;
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StopTransactionResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StopTransactionResponse.java
@@ -5,6 +5,7 @@ import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.enums.AuthorizationStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -27,6 +28,7 @@ public class StopTransactionResponse extends OCPPMessageResponse {
   @AllArgsConstructor
   public static class IdTagInfo {
 
+    @NotBlank(message = "StopTransactionResponse status is required")
     @SerializedName("status")
     private AuthorizationStatus status; // Status of the idTag (e.g., Accepted, Blocked, etc.).
   }

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -35,9 +35,9 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateObs
 
       // Ensure no constraint violations
       if (!MessageValidator.isValid(bootNotification)) {
-        /*        throw new IllegalArgumentException(
-        "BootNotification constraint violations: "
-            + MessageValidator.log_message(bootNotification));*/
+        throw new IllegalArgumentException(
+            "BootNotification constraint violations: "
+                + MessageValidator.log_message(bootNotification));
       } else {
         webSocketClient.pushMessage(new BootNotification());
       }

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -35,9 +35,7 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateObs
 
       // Ensure no constraint violations
       if (!MessageValidator.isValid(bootNotification)) {
-        throw new IllegalArgumentException(
-            "BootNotification constraint violations: "
-                + MessageValidator.log_message(bootNotification));
+        throw new IllegalArgumentException(MessageValidator.log_message(bootNotification));
       } else {
         webSocketClient.pushMessage(new BootNotification());
       }

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -10,6 +10,7 @@ import com.sim_backend.websockets.events.OnOCPPMessage;
 import com.sim_backend.websockets.events.OnOCPPMessageListener;
 import com.sim_backend.websockets.messages.BootNotification;
 import com.sim_backend.websockets.messages.BootNotificationResponse;
+import com.sim_backend.websockets.messages.MessageValidator;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 
@@ -30,7 +31,17 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateObs
 
     // Ensure current state is booting
     if (currState.getCurrentState() == SimulatorState.BootingUp) {
-      webSocketClient.pushMessage(new BootNotification());
+      BootNotification bootNotification = new BootNotification();
+
+      // Ensure no constraint violations
+      if (!MessageValidator.isValid(bootNotification)) {
+        /*        throw new IllegalArgumentException(
+        "BootNotification constraint violations: "
+            + MessageValidator.log_message(bootNotification));*/
+      } else {
+        webSocketClient.pushMessage(new BootNotification());
+      }
+
     } else
       throw new IllegalStateException(
           "Invalid machine state to send a boot notification: " + currState.getCurrentState());
@@ -48,6 +59,11 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateObs
 
     if (!(message.getMessage() instanceof BootNotificationResponse response))
       throw new ClassCastException("Message is not a BootNotificationResponse");
+
+    if (!MessageValidator.isValid(response)) {
+      throw new IllegalArgumentException(MessageValidator.log_message(response));
+    }
+
     MessageScheduler scheduler = message.getClient().getScheduler();
     long interval = response.getInterval();
 


### PR DESCRIPTION
Jakarta validation constraints used to create non-intrusive field validity enforcement. Jakarta does NOT throw automatically upon constraint violations. Instead, the message validator class can be used to validate any OCPPMessage. This helps reduce the amount of refactoring needed to implement validation. It also allows for specific constraint violations (and violation output) to be managed within the OCPPMessage class itself.

Ensures all OCPPMessages adhere to their JSON schema constraints
- All _required_ JSON properties are checked to ensure they are non-null.
- All JSON string properties must adhere to their respective max string length.
- All validation errors can be outputted via MessageValidator.log_message(OCPPMessage).