### PR TITLE
Fix rendering nested message payloads

### DIFF
--- a/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
@@ -173,10 +173,12 @@ public class MessageController extends ControllerBase {
   }
 
   public void getSentMessages(Context ctx) {
+    if (!checkWsClient(ctx)) return;
     ctx.json(charger.getWsClient().getSentMessages()); // Return sent messages as JSON
   }
 
   public void getReceivedMessages(Context ctx) {
+    if (!checkWsClient(ctx)) return;
     ctx.json(charger.getWsClient().getReceivedMessages()); // Return received messages as JSON
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -85,7 +85,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
     String timestamp = ZonedDateTime.now(ZoneOffset.UTC).toString();
     String messageWithTimestamp = message.replaceFirst("\\[", "[\"" + timestamp + "\", ");
     txMessages.add(messageWithTimestamp);
-    if (txMessages.size() > 20) {
+    if (txMessages.size() > 50) {
       txMessages.remove(0);
     }
   }
@@ -100,7 +100,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
     String modifiedMessage =
         message.replaceFirst("\\[", "[\"" + messageName + "\", \"" + timestamp + "\", ");
     rxMessages.add(modifiedMessage);
-    if (rxMessages.size() > 20) {
+    if (rxMessages.size() > 50) {
       rxMessages.remove(0);
     }
   }

--- a/frontend/src/components/buttons/RebootButton.js
+++ b/frontend/src/components/buttons/RebootButton.js
@@ -4,7 +4,7 @@ import ButtonBase from './ButtonBase';
 
 class RebootButtonLogic extends ButtonBase {
   constructor() {
-    super('Reboot', '/api/simulator/reboot'); // Set button name and endpoint
+    super('Reboot', '/api/charger/reboot'); // Set button name and endpoint
   }
 }
 


### PR DESCRIPTION
Messages with nesting in their payloads, like "idTagInfo" fields, would throw an error previously.

Also increase the max number of logged messages. I ran into a case where seeing an older message was useful, so I doubled it.