### PR TITLE
Allow for TLS connections

### DIFF
--- a/backend/src/main/java/com/sim_backend/transactions/StopTransactionHandler.java
+++ b/backend/src/main/java/com/sim_backend/transactions/StopTransactionHandler.java
@@ -52,5 +52,6 @@ public class StopTransactionHandler {
     // No listener is used here since a Central System cannot prevent a transaction from stopping
     System.out.println("Stop Transaction Completed...");
     stateMachine.transition(ChargerState.Available);
+    stopInProgress.set(false);
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/SniSSLSocketFactory.java
+++ b/backend/src/main/java/com/sim_backend/websockets/SniSSLSocketFactory.java
@@ -1,0 +1,115 @@
+package com.sim_backend.websockets;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.List;
+import javax.net.ssl.*;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+
+/**
+ * Custom SSLSocketFactory that ensures the Server Name Indication (SNI) is properly set on each
+ * SSLSocket.
+ *
+ * <p>SNI allows a client to indicate the hostname it is connecting to during the TLS handshake.
+ * This is important when multiple domains are served from the same IP address, so the server can
+ * select the appropriate certificate.
+ */
+public class SniSSLSocketFactory extends SSLSocketFactory {
+  // Underlying SSLSocketFactory that creates the actual socket instances
+  private final SSLSocketFactory delegate;
+  // Default hostname to use when no host is provided in createSocket()
+  private final String defaultHost;
+  // Default port to use when no port is provided in createSocket()
+  private final int defaultPort;
+
+  /**
+   * Constructs a new SniSSLSocketFactory.
+   *
+   * @param delegate A SSLSocketFactory.
+   * @param defaultHost The default hostname for socket creation.
+   * @param defaultPort The default port for socket creation.
+   */
+  public SniSSLSocketFactory(SSLSocketFactory delegate, String defaultHost, int defaultPort) {
+    this.delegate = delegate;
+    this.defaultHost = defaultHost;
+    this.defaultPort = defaultPort;
+  }
+
+  /**
+   * Enables Server Name Indication (SNI) on the provided socket.
+   *
+   * @param socket The socket on which to enable SNI.
+   * @param host The hostname to set for SNI.
+   * @return The socket with SNI configured.
+   */
+  private Socket enableSNI(Socket socket, String host) {
+    if (socket instanceof SSLSocket && host != null && !host.isEmpty()) {
+      SSLSocket sslSocket = (SSLSocket) socket;
+      SSLParameters sslParameters = sslSocket.getSSLParameters();
+      List<SNIServerName> serverNames = Collections.singletonList(new SNIHostName(host));
+      sslParameters.setServerNames(serverNames);
+      sslSocket.setSSLParameters(sslParameters);
+    }
+    return socket;
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    return delegate.getDefaultCipherSuites();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return delegate.getSupportedCipherSuites();
+  }
+
+  /**
+   * Creates a connected socket using the default host and port.
+   *
+   * <p>This method ensures that if a library calls the no-argument createSocket(), a socket
+   * connected to the intended default host and port is returned.
+   *
+   * @return A connected SSLSocket with SNI enabled.
+   * @throws IOException If an I/O error occurs.
+   */
+  @Override
+  public Socket createSocket() throws IOException {
+    return createSocket(defaultHost, defaultPort);
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) throws IOException {
+    Socket socket = delegate.createSocket(host, port);
+    return enableSNI(socket, host);
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+      throws IOException {
+    Socket socket = delegate.createSocket(host, port, localHost, localPort);
+    return enableSNI(socket, host);
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port) throws IOException {
+    Socket socket = delegate.createSocket(address, port);
+    return enableSNI(socket, address.getHostName());
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+      throws IOException {
+    Socket socket = delegate.createSocket(address, port, localAddress, localPort);
+    return enableSNI(socket, address.getHostName());
+  }
+
+  @Override
+  public Socket createSocket(Socket s, String host, int port, boolean autoClose)
+      throws IOException {
+    Socket socket = delegate.createSocket(s, host, port, autoClose);
+    return enableSNI(socket, host);
+  }
+}

--- a/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
@@ -23,7 +23,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 public class MessageSchedulerTest {
-  
+
   @Spy private TestOCPPWebSocketClient client = new TestOCPPWebSocketClient(new URI(""));
 
   @Spy private OCPPTime time = new OCPPTime(client);

--- a/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
@@ -3,6 +3,7 @@ package com.sim_backend.websockets;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.sim_backend.websockets.OCPPWebSocketClientTest.TestOCPPWebSocketClient;
 import com.sim_backend.websockets.messages.Heartbeat;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPRepeatingTimedTask;
@@ -22,7 +23,8 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 public class MessageSchedulerTest {
-  @Spy private OCPPWebSocketClient client = new OCPPWebSocketClient(new URI(""));
+  
+  @Spy private TestOCPPWebSocketClient client = new TestOCPPWebSocketClient(new URI(""));
 
   @Spy private OCPPTime time = new OCPPTime(client);
 
@@ -36,7 +38,7 @@ public class MessageSchedulerTest {
   void setUp() throws URISyntaxException {
     MockitoAnnotations.openMocks(this);
     when(time.getSynchronizedTime()).thenReturn(ZonedDateTime.now());
-    client = spy(new OCPPWebSocketClient(new URI("ws://localhost:8080/sim_backend")));
+    client = spy(new TestOCPPWebSocketClient(new URI("ws://localhost:8080/sim_backend")));
     scheduler =
         new MessageScheduler(client) {
           @Override

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPTimeTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPTimeTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.sim_backend.websockets.enums.ErrorCode;
+import com.sim_backend.websockets.OCPPWebSocketClientTest.TestOCPPWebSocketClient;
 import com.sim_backend.websockets.events.OnOCPPMessage;
 import com.sim_backend.websockets.events.OnOCPPMessageListener;
 import com.sim_backend.websockets.exceptions.OCPPMessageFailure;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class OCPPTimeTest {
   public static final ZoneId UTC = ZoneId.of("UTC");
 
-  OCPPWebSocketClient client;
+  TestOCPPWebSocketClient client;
   MessageQueue queue;
   OnOCPPMessage onOCPPMessageMock;
   OCPPTime ocppTime;
@@ -31,7 +32,7 @@ public class OCPPTimeTest {
   @BeforeEach
   void setUp() throws URISyntaxException {
     onOCPPMessageMock = mock(OnOCPPMessage.class);
-    client = spy(new OCPPWebSocketClient(new URI("")));
+    client = spy(new TestOCPPWebSocketClient(new URI("")));
     ocppTime = client.getScheduler().getTime();
   }
 

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPTimeTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPTimeTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.sim_backend.websockets.enums.ErrorCode;
 import com.sim_backend.websockets.OCPPWebSocketClientTest.TestOCPPWebSocketClient;
+import com.sim_backend.websockets.enums.ErrorCode;
 import com.sim_backend.websockets.events.OnOCPPMessage;
 import com.sim_backend.websockets.events.OnOCPPMessageListener;
 import com.sim_backend.websockets.exceptions.OCPPMessageFailure;

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -25,14 +25,33 @@ import org.junit.jupiter.api.Test;
 
 public class OCPPWebSocketClientTest {
 
-  OCPPWebSocketClient client;
+  public static class TestOCPPWebSocketClient extends OCPPWebSocketClient {
+    public TestOCPPWebSocketClient(URI serverUri) {
+      super(serverUri);
+    }
+
+    @Override
+    public void startConnectionLostTimer() {}
+
+    @Override
+    public boolean connectBlocking() throws InterruptedException {
+      return true;
+    }
+
+    @Override
+    public boolean reconnectBlocking() throws InterruptedException {
+      return true;
+    }
+  }
+
+  TestOCPPWebSocketClient client;
   MessageQueue queue;
   OnOCPPMessage onOCPPMessageMock;
 
   @BeforeEach
   void setUp() throws URISyntaxException {
     onOCPPMessageMock = mock(OnOCPPMessage.class);
-    client = spy(new OCPPWebSocketClient(new URI("")));
+    client = spy(new TestOCPPWebSocketClient(new URI("")));
     queue = mock(MessageQueue.class);
   }
 
@@ -612,7 +631,7 @@ public class OCPPWebSocketClientTest {
     heartbeat.setMessageID(testMsgId);
 
     // Get the MessageQueue from our client
-    OCPPWebSocketClient client = new OCPPWebSocketClient(new java.net.URI("ws://dummy"));
+    TestOCPPWebSocketClient client = new TestOCPPWebSocketClient(new java.net.URI("ws://dummy"));
 
     // Access previousMessages
     Field previousMessagesField = MessageQueue.class.getDeclaredField("previousMessages");
@@ -754,7 +773,7 @@ public class OCPPWebSocketClientTest {
     // Given a "wss" URI
     URI wssUri = new URI("wss://example.com:12345");
 
-    OCPPWebSocketClient client = new OCPPWebSocketClient(wssUri);
+    TestOCPPWebSocketClient client = new TestOCPPWebSocketClient(wssUri);
 
     // Verify the WebSocketClient's 'socketFactory' is SniSSLSocketFactory
     Field socketFactoryField = getSocketFactoryField();
@@ -771,7 +790,7 @@ public class OCPPWebSocketClientTest {
     // Given a "ws" URI
     URI wsUri = new URI("ws://example.com:12345");
 
-    OCPPWebSocketClient client = new OCPPWebSocketClient(wsUri);
+    TestOCPPWebSocketClient client = new TestOCPPWebSocketClient(wsUri);
 
     // Verify the WebSocketClient's 'socketFactory' is not SniSSLSocketFactory
     Field socketFactoryField = getSocketFactoryField();

--- a/backend/src/test/java/com/sim_backend/websockets/SniSSLSocketFactoryTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/SniSSLSocketFactoryTest.java
@@ -1,0 +1,129 @@
+package com.sim_backend.websockets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.List;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+
+public class SniSSLSocketFactoryTest {
+
+  private static final String DEFAULT_HOST = "defaultHost";
+  private static final int DEFAULT_PORT = 443;
+
+  private SSLSocketFactory delegate;
+  private SniSSLSocketFactory sniSSLSocketFactory;
+
+  @BeforeEach
+  void setUp() {
+    delegate = mock(SSLSocketFactory.class);
+    sniSSLSocketFactory = new SniSSLSocketFactory(delegate, DEFAULT_HOST, DEFAULT_PORT);
+  }
+
+  /**
+   * Verifies that the no-arg createSocket() calls delegate with default host and port, and sets SNI
+   * on an SSLSocket.
+   */
+  @Test
+  void testCreateSocket_noArg_usesDefaultHostAndPort() throws IOException {
+    SSLSocket mockSslSocket = mock(SSLSocket.class);
+    SSLParameters sslParameters = new SSLParameters();
+    when(mockSslSocket.getSSLParameters()).thenReturn(sslParameters);
+
+    // Configure delegate to return the mock SSLSocket for the default host/port
+    when(delegate.createSocket(DEFAULT_HOST, DEFAULT_PORT)).thenReturn(mockSslSocket);
+
+    // Test
+    Socket socket = sniSSLSocketFactory.createSocket();
+
+    // Verify that delegate's createSocket was called with defaultHost and defaultPort
+    verify(delegate, times(1)).createSocket(DEFAULT_HOST, DEFAULT_PORT);
+
+    // Verify that we got back our mock SSLSocket
+    assertNotNull(socket);
+
+    // Verify that setSSLParameters was called with the correct SNI
+    verify(mockSslSocket).setSSLParameters(argThat(new SniMatcher(DEFAULT_HOST)));
+  }
+
+  /** Verifies that createSocket(host, port) calls the delegate correctly and sets SNI. */
+  @Test
+  void testCreateSocket_withHostAndPort_setsSNI() throws IOException {
+    String customHost = "example.com";
+    int customPort = 12345;
+
+    // Mock an SSLSocket returned by the delegate
+    SSLSocket mockSslSocket = mock(SSLSocket.class);
+    SSLParameters sslParameters = new SSLParameters();
+    when(mockSslSocket.getSSLParameters()).thenReturn(sslParameters);
+
+    // Configure delegate to return the mock SSLSocket
+    when(delegate.createSocket(customHost, customPort)).thenReturn(mockSslSocket);
+
+    // Test
+    Socket socket = sniSSLSocketFactory.createSocket(customHost, customPort);
+
+    // Verify the delegate createSocket was called with the provided host and port
+    verify(delegate, times(1)).createSocket(customHost, customPort);
+
+    // Verify SNI was configured
+    verify(mockSslSocket).setSSLParameters(argThat(new SniMatcher(customHost)));
+    assertNotNull(socket);
+  }
+
+  /**
+   * Verifies that if the underlying socket is not an SSLSocket, no SNI configuration is attempted.
+   */
+  @Test
+  void testCreateSocket_notSSLSocket_noSNI() throws IOException {
+    String host = "example.com";
+    int port = 12345;
+
+    // Mock a plain Socket (not SSLSocket)
+    Socket mockSocket = mock(Socket.class);
+
+    // Configure delegate to return the plain Socket
+    when(delegate.createSocket(host, port)).thenReturn(mockSocket);
+
+    // Test
+    Socket socket = sniSSLSocketFactory.createSocket(host, port);
+
+    // Verify the delegate createSocket was called
+    verify(delegate, times(1)).createSocket(host, port);
+
+    // Verify we did not set SSL parameters
+    verifyNoMoreInteractions(mockSocket);
+    assertNotNull(socket);
+  }
+
+  /** Helper to check the SNI host name. */
+  private static class SniMatcher implements ArgumentMatcher<SSLParameters> {
+    private final String expectedHost;
+
+    private SniMatcher(String expectedHost) {
+      this.expectedHost = expectedHost;
+    }
+
+    @Override
+    public boolean matches(SSLParameters sslParameters) {
+      List<SNIServerName> sniServerNames = sslParameters.getServerNames();
+      if (sniServerNames == null || sniServerNames.size() != 1) {
+        return false;
+      }
+      SNIServerName serverName = sniServerNames.get(0);
+      if (serverName instanceof SNIHostName) {
+        return ((SNIHostName) serverName).getAsciiName().equals(expectedHost);
+      }
+      return false;
+    }
+  }
+}

--- a/backend/src/test/java/com/sim_backend/websockets/messages/HeartbeatTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/HeartbeatTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 import com.google.gson.JsonElement;
 import com.networknt.schema.*;
 import com.sim_backend.websockets.GsonUtilities;
-import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.OCPPWebSocketClientTest.TestOCPPWebSocketClient;
 import com.sim_backend.websockets.types.OCPPMessage;
 import java.io.InputStream;
 import java.net.URI;
@@ -20,11 +20,11 @@ import org.junit.jupiter.api.Test;
 
 public class HeartbeatTest {
 
-  OCPPWebSocketClient client;
+  TestOCPPWebSocketClient client;
 
   @BeforeEach
   void setUp() throws URISyntaxException {
-    client = spy(new OCPPWebSocketClient(new URI("")));
+    client = spy(new TestOCPPWebSocketClient(new URI("")));
   }
 
   @Test

--- a/backend/src/test/java/com/sim_backend/websockets/messages/StartTransactionTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/StartTransactionTest.java
@@ -7,7 +7,7 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.ValidationMessage;
 import com.sim_backend.websockets.GsonUtilities;
 import com.sim_backend.websockets.OCPPTime;
-import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.OCPPWebSocketClientTest.TestOCPPWebSocketClient;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
@@ -18,12 +18,12 @@ import org.junit.jupiter.api.Test;
 
 public class StartTransactionTest {
 
-  OCPPWebSocketClient client;
+  TestOCPPWebSocketClient client;
   String time;
 
   @BeforeEach
   void setUp() throws URISyntaxException {
-    client = spy(new OCPPWebSocketClient(new URI("")));
+    client = spy(new TestOCPPWebSocketClient(new URI("")));
     OCPPTime ocppTime = client.getScheduler().getTime();
     ZonedDateTime zonetime = ocppTime.getSynchronizedTime();
     time = zonetime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX"));


### PR DESCRIPTION
Add code for setting up SSL when connecting to `wss://` urls. Also adds a socket factory that ensures SNI is set. The simulator was unable to connect to the Ranger EV backend backend without it.

Note: the OCPP-J 1.6 spec mentions authorization via `6.2. OCPP-J over TLS`. This PR implements `6.1. Network-level security`. The Ranger EV backend link is a `wss://` and does not require the HTTP authorization headers described in `6.2. OCPP-J over TLS`.