### PR TITLE
Add message timeout handling

### DIFF
--- a/backend/src/main/java/com/sim_backend/charger/ChargerLoop.java
+++ b/backend/src/main/java/com/sim_backend/charger/ChargerLoop.java
@@ -1,5 +1,6 @@
 package com.sim_backend.charger;
 
+import com.sim_backend.websockets.OCPPWebSocketClient;
 import com.sim_backend.websockets.exceptions.OCPPMessageFailure;
 
 /**
@@ -37,8 +38,10 @@ public class ChargerLoop implements Runnable {
    */
   public boolean process() {
     try {
-      charger.getWsClient().getScheduler().tick();
-      charger.getWsClient().popAllMessages();
+      OCPPWebSocketClient wsClient = charger.getWsClient();
+      wsClient.getScheduler().tick();
+      wsClient.getQueue().checkTimeouts(wsClient);
+      wsClient.popAllMessages();
     } catch (OCPPMessageFailure e) {
       // TODO: Add error handling for OCPP message failures
     } catch (InterruptedException e) {

--- a/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
@@ -168,7 +168,10 @@ public class MessageController extends ControllerBase {
       String info = json.has("info") ? json.get("info").getAsString().trim() : null;
       if (info != null && info.isEmpty()) info = null;
 
-      ZonedDateTime timestamp = json.has("timestamp") ? ZonedDateTime.now() : null;
+      ZonedDateTime timestamp =
+          json.has("timestamp")
+              ? charger.getWsClient().getScheduler().getTime().getSynchronizedTime()
+              : null;
 
       String vendorId = json.has("vendorId") ? json.get("vendorId").getAsString().trim() : null;
       if (vendorId != null && vendorId.isEmpty()) vendorId = null;

--- a/backend/src/main/java/com/sim_backend/transactions/StopTransactionHandler.java
+++ b/backend/src/main/java/com/sim_backend/transactions/StopTransactionHandler.java
@@ -5,8 +5,7 @@ import com.sim_backend.state.ChargerState;
 import com.sim_backend.state.ChargerStateMachine;
 import com.sim_backend.websockets.OCPPTime;
 import com.sim_backend.websockets.OCPPWebSocketClient;
-import com.sim_backend.websockets.enums.*;
-import com.sim_backend.websockets.messages.*;
+import com.sim_backend.websockets.messages.StopTransaction;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -28,7 +27,7 @@ public class StopTransactionHandler {
   }
 
   /**
-   * Initiate StopTransaction, handles StopTransaction requests, responses and charger status
+   * Initiate StopTransaction, handles StopTransaction requests, responses and charger status.
    *
    * @param transactionId transactionId from StartTransaction
    * @param idTag id of user
@@ -50,17 +49,8 @@ public class StopTransactionHandler {
         new StopTransaction(idTag, transactionId, meterStop, timestamp);
     client.pushMessage(stopTransactionMessage);
 
-    client.onReceiveMessage(
-        StopTransactionResponse.class,
-        message -> {
-          if (!(message.getMessage() instanceof StopTransactionResponse)) {
-            throw new ClassCastException("Message is not a StopTransactionResponse");
-          }
-          // The central system cannot prevent a StopTransaction
-          System.out.println("Stop Transaction Completed...");
-          stateMachine.transition(ChargerState.Available);
-          client.clearOnReceiveMessage(StopTransactionResponse.class);
-          stopInProgress.set(false);
-        });
+    // No listener is used here since a Central System cannot prevent a transaction from stopping
+    System.out.println("Stop Transaction Completed...");
+    stateMachine.transition(ChargerState.Available);
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/MessageQueue.java
+++ b/backend/src/main/java/com/sim_backend/websockets/MessageQueue.java
@@ -65,6 +65,21 @@ public class MessageQueue {
   }
 
   /**
+   * Add a OCPPMessage to the front of our send queue.
+   *
+   * @param prioMessage the message to be sent.
+   */
+  public boolean pushPriorityMessage(final OCPPMessage prioMessage) {
+    if (queueSet.contains(prioMessage)) {
+      return false;
+    }
+
+    queue.addFirst(prioMessage);
+    queueSet.add(prioMessage);
+    return true;
+  }
+
+  /**
    * Return the size of the send queue.
    *
    * @return size in int.

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -57,7 +57,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
   public static final String MESSAGE_PACKAGE = "com.sim_backend.websockets.messages";
 
   /** The OCPP Message Queue. */
-  private final MessageQueue queue = new MessageQueue();
+  @Getter final MessageQueue queue = new MessageQueue();
 
   /** Our online status */
   @Getter private boolean Online = true;
@@ -334,6 +334,21 @@ public class OCPPWebSocketClient extends WebSocketClient {
   public boolean pushMessage(final OCPPMessage message) {
     recordTxMessage(message.toJsonString()); // Record transmitted message
     return queue.pushMessage(message);
+  }
+
+  /**
+   * Add a OCPPMessage to the front of our send queue.
+   *
+   * @param message the message to be sent.
+   */
+  public boolean pushPriorityMessage(final OCPPMessage prioMessage) {
+    if (queue.getQueueSet().contains(prioMessage)) {
+      return false;
+    }
+    recordTxMessage(prioMessage.toJsonString());
+    queue.getQueue().addFirst(prioMessage);
+    queue.getQueueSet().add(prioMessage);
+    return true;
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -339,16 +339,11 @@ public class OCPPWebSocketClient extends WebSocketClient {
   /**
    * Add a OCPPMessage to the front of our send queue.
    *
-   * @param message the message to be sent.
+   * @param prioMessage the message to be sent.
    */
   public boolean pushPriorityMessage(final OCPPMessage prioMessage) {
-    if (queue.getQueueSet().contains(prioMessage)) {
-      return false;
-    }
     recordTxMessage(prioMessage.toJsonString());
-    queue.getQueue().addFirst(prioMessage);
-    queue.getQueueSet().add(prioMessage);
-    return true;
+    return queue.pushPriorityMessage(prioMessage);
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/events/OnOCPPMessageListener.java
+++ b/backend/src/main/java/com/sim_backend/websockets/events/OnOCPPMessageListener.java
@@ -3,9 +3,18 @@ package com.sim_backend.websockets.events;
 /** A Listener for an OnOCPPMessage event. */
 public interface OnOCPPMessageListener {
   /**
-   * The method to be called.
+   * The method to be called when a response message is received.
    *
    * @param message The OCPP message event.
    */
   void onMessageReceived(OnOCPPMessage message);
+
+  /**
+   * Called when a response message times out.
+   *
+   * <p>Default implementation does nothing.
+   */
+  default void onTimeout() {
+    // Default: do nothing
+  }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StartTransactionResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StartTransactionResponse.java
@@ -7,6 +7,7 @@ import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,6 +17,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@EqualsAndHashCode(callSuper = true)
 @OCPPMessageInfo(
     messageCallID = OCPPMessage.CALL_ID_RESPONSE,
     messageName = "StartTransactionResponse")

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StatusNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StatusNotificationResponse.java
@@ -3,11 +3,13 @@ package com.sim_backend.websockets.messages;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
+import lombok.EqualsAndHashCode;
 
 /**
  * Represents an OCPP 1.6 Status Notification Response sent by the Central System to acknowledge a
  * Status Notification Request.
  */
+@EqualsAndHashCode(callSuper = true)
 @OCPPMessageInfo(
     messageCallID = OCPPMessage.CALL_ID_RESPONSE,
     messageName = "StatusNotificationResponse")

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StopTransactionResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StopTransactionResponse.java
@@ -7,6 +7,7 @@ import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,6 +17,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@EqualsAndHashCode(callSuper = true)
 @OCPPMessageInfo(
     messageCallID = OCPPMessage.CALL_ID_RESPONSE,
     messageName = "StopTransactionResponse")

--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -103,6 +103,12 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateObs
   }
 
   @Override
+  /** If the BootNotification times out, retry it with top priority. */
+  public void onTimeout() {
+    webSocketClient.pushPriorityMessage(new BootNotification());
+  }
+
+  @Override
   public void onStateChanged(ChargerState newState) {
     if (newState == ChargerState.BootingUp) {
       handleBootNotificationRequest();

--- a/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
+++ b/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
@@ -160,7 +160,6 @@ class MessageControllerTest {
             + "\"errorCode\": \"NoError\","
             + "\"info\": \"\","
             + "\"status\": \"Available\","
-            + "\"timestamp\": \"2025-02-02T12:00:00Z\","
             + "\"vendorId\": \"\","
             + "\"vendorErrorCode\": \"\""
             + "}";

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -12,8 +12,12 @@ import com.sim_backend.websockets.events.OnOCPPMessageListener;
 import com.sim_backend.websockets.exceptions.*;
 import com.sim_backend.websockets.messages.*;
 import com.sim_backend.websockets.types.OCPPMessageError;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -540,5 +544,100 @@ public class OCPPWebSocketClientTest {
     client.popAllMessages();
 
     verify(client, times(0)).send(anyString());
+  }
+
+  @Test
+  public void testPushPriorityMessageSuccess() {
+    // Clear the internal queue for a clean start
+    client.queue.getQueue().clear();
+    client.queue.getQueueSet().clear();
+
+    // Start the queue with a single message
+    client.pushMessage(new BootNotification());
+
+    int initialTxMessages = client.getSentMessages().size();
+    Heartbeat heartbeat = new Heartbeat();
+
+    // Push a priority message; should return true
+    boolean result = client.pushPriorityMessage(heartbeat);
+    assertTrue(result, "Push priority message should return true when message is not in the queue");
+
+    // Verify the message is now at the front of the queue
+    assertFalse(client.isEmpty(), "Queue should not be empty after push");
+    assertEquals(
+        heartbeat,
+        client.queue.getQueue().peekFirst(),
+        "Priority message should be at the front of the queue");
+    assertTrue(
+        client.queue.getQueueSet().contains(heartbeat),
+        "Queue set should contain the pushed message");
+
+    // Verify that the message was recorded in the transmitted messages list
+    assertEquals(
+        initialTxMessages + 1,
+        client.getSentMessages().size(),
+        "A transmitted message should be recorded");
+  }
+
+  @Test
+  public void testPushPriorityMessageDuplicate() {
+    // Clear the internal queue for a clean start
+    client.queue.getQueue().clear();
+    client.queue.getQueueSet().clear();
+
+    Heartbeat heartbeat = new Heartbeat();
+
+    // First push should succeed
+    boolean firstPush = client.pushPriorityMessage(heartbeat);
+    assertTrue(firstPush, "First push priority message should succeed");
+
+    // Attempting to push the same message again should fail
+    boolean secondPush = client.pushPriorityMessage(heartbeat);
+    assertFalse(secondPush, "Duplicate push priority message should return false");
+
+    // The queue should only contain one instance of the message
+    assertEquals(
+        1,
+        client.queue.getQueue().size(),
+        "Queue should contain only one message after duplicate push attempt");
+  }
+
+  @Test
+  public void testCheckTimeouts() throws Exception {
+    // Create a Heartbeat message that will be timed out
+    Heartbeat heartbeat = new Heartbeat();
+    String testMsgId = "timeout-test";
+    heartbeat.setMessageID(testMsgId);
+
+    // Get the MessageQueue from our client
+    OCPPWebSocketClient client = new OCPPWebSocketClient(new java.net.URI("ws://dummy"));
+
+    // Access previousMessages
+    Field previousMessagesField = MessageQueue.class.getDeclaredField("previousMessages");
+    previousMessagesField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, MessageQueue.TimedMessage> previousMessages =
+        (Map<String, MessageQueue.TimedMessage>) previousMessagesField.get(client.getQueue());
+
+    // Insert the message with a timestamp older than RESPONSE_TIME_OUT seconds
+    MessageQueue.TimedMessage timedMessage =
+        new MessageQueue.TimedMessage(
+            heartbeat, Instant.now().minus(Duration.ofSeconds(MessageQueue.RESPONSE_TIME_OUT + 5)));
+    previousMessages.put(heartbeat.getMessageID(), timedMessage);
+
+    // Register a listener for the complementary message type
+    OnOCPPMessageListener listener = mock(OnOCPPMessageListener.class);
+    client.onReceiveMessage(HeartbeatResponse.class, listener);
+
+    // Call checkTimeouts, which should trigger onTimeout() for the listener
+    client.getQueue().checkTimeouts(client);
+
+    // Verify that the onTimeout method was called once.
+    verify(listener, times(1)).onTimeout();
+
+    // Verify that the timed-out message was removed from previousMessages
+    assertFalse(
+        previousMessages.containsKey(testMsgId),
+        "Timed-out message should be removed from previousMessages");
   }
 }

--- a/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
@@ -108,7 +108,6 @@ class BootNotificationObserverTest {
   @Test
   void onMessageReceived_WhenStatusRejected_RegistersJob() {
     // Arrange
-    // Arrange
     BootNotificationResponse response =
         Mockito.spy(
             new BootNotificationResponse(RegistrationStatus.REJECTED, ZonedDateTime.now(), 240));
@@ -162,5 +161,14 @@ class BootNotificationObserverTest {
 
     // Assert
     verify(webSocketClient, never()).pushMessage(any());
+  }
+
+  @Test
+  void onTimeout_SendsPriorityNotification() {
+    // Act
+    observer.onTimeout();
+
+    // Assert: Verify that a BootNotification is pushed with top priority
+    verify(webSocketClient).pushPriorityMessage(isBootNotification());
   }
 }


### PR DESCRIPTION
For some observers, a message timeout would previously lock up the simulator and leave it in a bad state. This PR adds the onTimeout() function to the OCPPMessageListener interface. By default, onTimeout() does nothing.

The following timeout handling was added to observers:
Authorize (before StartTransaction): Resets state to "Available"
StartTransaction: Resets state to "Available"
StopTransaction: Nothing, the listener was removed since the central system cannot prevent a transaction from stopping
BootNotification: The BootNotification is now retried with priority