### PR TITLE
CSCAP-128 Append the offline status to the status endpoint

### DIFF
--- a/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
+++ b/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
@@ -97,12 +97,26 @@ class MessageControllerTest {
   void testState() {
     // Arrange
     when(mockStateMachine.getCurrentState()).thenReturn(ChargerState.PoweredOff);
+    when(mockWsClient.isOnline()).thenReturn(true);
 
     // Act
     messageController.state(mockContext);
 
     // Assert
     verify(mockContext).result("PoweredOff");
+  }
+
+  @Test
+  void testStateOffline() {
+    // Arrange
+    when(mockStateMachine.getCurrentState()).thenReturn(ChargerState.PoweredOff);
+    when(mockWsClient.isOnline()).thenReturn(false);
+
+    // Act
+    messageController.state(mockContext);
+
+    // Assert
+    verify(mockContext).result("PoweredOff (Offline)");
   }
 
   @Test


### PR DESCRIPTION
If the simulator is offline, append " (Offline)" to the reported state in the state endpoint. This will then automatically display in the frontend. So a user will see something like "Available (Offline)" in the UI.