### PR TITLE
Add faulted state + more thread safety

### DIFF
--- a/backend/src/main/java/com/sim_backend/Main.java
+++ b/backend/src/main/java/com/sim_backend/Main.java
@@ -28,7 +28,7 @@ public final class Main {
 
     // Start the charger
     for (Charger charger : chargers) {
-      charger.Boot();
+      charger.boot();
     }
   }
 

--- a/backend/src/main/java/com/sim_backend/state/ChargerState.java
+++ b/backend/src/main/java/com/sim_backend/state/ChargerState.java
@@ -5,5 +5,6 @@ public enum ChargerState {
   BootingUp,
   Available,
   Preparing,
-  Charging
+  Charging,
+  Faulted
 }

--- a/backend/src/main/java/com/sim_backend/transactions/StartTransactionHandler.java
+++ b/backend/src/main/java/com/sim_backend/transactions/StartTransactionHandler.java
@@ -76,10 +76,10 @@ public class StartTransactionHandler {
               transactionId.set(response.getTransactionId());
               System.out.println(
                   "Start Transaction Completed... Transaction Id : " + response.getTransactionId());
-              stateMachine.transition(ChargerState.Charging);
+              stateMachine.checkAndTransition(ChargerState.Preparing, ChargerState.Charging);
             } else {
               System.err.println("Transaction Failed to Start...");
-              stateMachine.transition(ChargerState.Available);
+              stateMachine.checkAndTransition(ChargerState.Preparing, ChargerState.Available);
             }
             startInProgress.set(false);
           }
@@ -89,7 +89,7 @@ public class StartTransactionHandler {
             client.deleteOnReceiveMessage(StartTransactionResponse.class, this);
             System.err.println("Start Transaction timeout. Resetting transaction state.");
             startInProgress.set(false);
-            stateMachine.transition(ChargerState.Available);
+            stateMachine.checkAndTransition(ChargerState.Preparing, ChargerState.Available);
           }
         };
 

--- a/backend/src/main/java/com/sim_backend/websockets/enums/Reason.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/Reason.java
@@ -1,0 +1,73 @@
+package com.sim_backend.websockets.enums;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** Enum representing the reason for stopping a transaction in a StopTransaction. */
+@Getter
+@RequiredArgsConstructor
+public enum Reason {
+
+  /* The transaction was stopped because of the authorization status in a StartTransaction.conf */
+  @SerializedName("DeAuthorized")
+  DE_AUTHORIZED("DeAuthorized"),
+
+  /* Emergency stop button was used */
+  @SerializedName("EmergencyStop")
+  EMERGENCY_STOP("EmergencyStop"),
+
+  /* disconnecting of cable, vehicle moved away from inductive charge unit */
+  @SerializedName("EVDisconnected")
+  EV_DISCONNECTED("EVDisconnected"),
+
+  /* A hard reset command was received */
+  @SerializedName("HardReset")
+  HARD_RESET("HardReset"),
+
+  /* Stopped locally on request of the user at the Charge Point */
+  @SerializedName("Local")
+  LOCAL("Local"),
+
+  /* Any other reason */
+  @SerializedName("Other")
+  OTHER("Other"),
+
+  /* Complete loss of power */
+  @SerializedName("PowerLoss")
+  POWER_LOSS("PowerLoss"),
+
+  /* A locally initiated reset/reboot occurred */
+  @SerializedName("Reboot")
+  REBOOT("Reboot"),
+
+  /*Stopped remotely on request of the user */
+  @SerializedName("Remote")
+  REMOTE("Remote"),
+
+  /* A soft reset command was received */
+  @SerializedName("SoftReset")
+  SOFT_RESET("SoftReset"),
+
+  /* Central System sent an Unlock Connector command */
+  @SerializedName("UnlockCommand")
+  UNLOCK_COMMAND("UnlockCommand");
+
+  private final String value;
+
+  /**
+   * Converts a string to its corresponding enum value.
+   *
+   * @param value The string representation of the enum.
+   * @return The corresponding Reason enum.
+   * @throws IllegalArgumentException if the value is invalid.
+   */
+  public static Reason fromValue(String value) {
+    for (Reason reason : values()) {
+      if (reason.value.equals(value)) {
+        return reason;
+      }
+    }
+    throw new IllegalArgumentException("Invalid Reason: " + value);
+  }
+}

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotification.java
@@ -88,7 +88,7 @@ public final class BootNotification extends OCPPMessageRequest implements Clonea
   }
 
   @Override
-  protected Authorize clone() {
-    return (Authorize) super.clone();
+  protected BootNotification clone() {
+    return (BootNotification) super.clone();
   }
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StopTransaction.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StopTransaction.java
@@ -2,6 +2,7 @@ package com.sim_backend.websockets.messages;
 
 import com.google.gson.annotations.SerializedName;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
+import com.sim_backend.websockets.enums.Reason;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageRequest;
 import jakarta.validation.constraints.NotNull;
@@ -35,12 +36,33 @@ public class StopTransaction extends OCPPMessageRequest implements Cloneable {
   @SerializedName("timestamp")
   private String timestamp;
 
-  // Constructor
+  @SerializedName("reason")
+  private Reason reason;
+
+  // Constructor with no reason and no idTag
   public StopTransaction(String idTag, int transactionId, int meterStop, String timestamp) {
     this.idTag = idTag;
     this.transactionId = transactionId;
     this.meterStop = meterStop;
     this.timestamp = timestamp;
+  }
+
+  // Constructor with reason and no idTag
+  public StopTransaction(int transactionId, int meterStop, String timestamp, Reason reason) {
+    this.transactionId = transactionId;
+    this.meterStop = meterStop;
+    this.timestamp = timestamp;
+    this.reason = reason;
+  }
+
+  // Constructor with idTag and reason
+  public StopTransaction(
+      String idTag, int transactionId, int meterStop, String timestamp, Reason reason) {
+    this.idTag = idTag;
+    this.transactionId = transactionId;
+    this.meterStop = meterStop;
+    this.timestamp = timestamp;
+    this.reason = reason;
   }
 
   @Override

--- a/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
+++ b/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
@@ -126,13 +126,13 @@ class MessageControllerTest {
   @Test
   void testRebootNormal() {
     // Arrange
-    doNothing().when(mockCharger).Reboot();
+    doNothing().when(mockCharger).reboot();
 
     // Act
     messageController.reboot(mockContext);
 
     // Assert
-    verify(mockCharger).Reboot();
+    verify(mockCharger).reboot();
     verify(mockContext).result("OK");
   }
 
@@ -147,7 +147,7 @@ class MessageControllerTest {
     // Assert
     verify(mockContext).status(503);
     verify(mockContext).result("Reboot already in progress");
-    verify(mockCharger, never()).Reboot();
+    verify(mockCharger, never()).reboot();
   }
 
   @Test
@@ -171,13 +171,13 @@ class MessageControllerTest {
   @Test
   void testStatus() {
     // Arrange
+    when(mockStateMachine.getCurrentState()).thenReturn(ChargerState.Available);
     doReturn(true).when(mockWsClient).pushMessage(any(StatusNotification.class));
     String jsonRequest =
         "{"
             + "\"connectorId\": \"1\","
             + "\"errorCode\": \"NoError\","
             + "\"info\": \"\","
-            + "\"status\": \"Available\","
             + "\"vendorId\": \"\","
             + "\"vendorErrorCode\": \"\""
             + "}";
@@ -191,6 +191,15 @@ class MessageControllerTest {
   }
 
   @Test
+  void testClearFault() {
+    // Act
+    messageController.clearFault(mockContext);
+
+    // Assert
+    verify(mockCharger).clearFault();
+  }
+
+  @Test
   void testStartCharge() {
     // Arrange
     when(mockConfig.getIdTag()).thenReturn("testIdTag");
@@ -199,7 +208,7 @@ class MessageControllerTest {
     messageController.startCharge(mockContext);
 
     // Assert
-    verify(mockTHandler).StartCharging(eq(1), eq("testIdTag"));
+    verify(mockTHandler).startCharging(eq(1), eq("testIdTag"));
     verify(mockContext).result("OK");
   }
 
@@ -212,7 +221,7 @@ class MessageControllerTest {
     messageController.stopCharge(mockContext);
 
     // Assert
-    verify(mockTHandler).StopCharging(eq("testIdTag"));
+    verify(mockTHandler).stopCharging(eq("testIdTag"), eq(null));
     verify(mockContext).result("OK");
   }
 
@@ -265,6 +274,7 @@ class MessageControllerTest {
     verify(mockApp).post(eq("/api/{chargerId}/message/heartbeat"), any());
     verify(mockApp).get(eq("/api/{chargerId}/state"), any());
     verify(mockApp).post(eq("/api/{chargerId}/charger/reboot"), any());
+    verify(mockApp).post(eq("/api/{chargerId}/charger/clear-fault"), any());
     verify(mockApp).post(eq("/api/{chargerId}/state/online"), any());
     verify(mockApp).post(eq("/api/{chargerId}/state/offline"), any());
     verify(mockApp).post(eq("/api/{chargerId}/state/status"), any());

--- a/backend/src/test/java/com/sim_backend/state/StateTest.java
+++ b/backend/src/test/java/com/sim_backend/state/StateTest.java
@@ -1,6 +1,8 @@
 package com.sim_backend.state;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,5 +86,137 @@ public class StateTest {
         ChargerState.PoweredOff,
         testStateMachine.getCurrentState(),
         "Transition from Charging to PoweredOff should be allowed");
+  }
+
+  @Test
+  void testTransitionToFaulted() {
+    // Transition from Available to Faulted
+    testStateMachine.transition(ChargerState.BootingUp);
+    testStateMachine.transition(ChargerState.Available);
+    testStateMachine.transition(ChargerState.Faulted);
+    assertEquals(
+        ChargerState.Faulted,
+        testStateMachine.getCurrentState(),
+        "Transition from Available to Faulted should be allowed");
+
+    // Transition from Preparing to Faulted
+    testStateMachine.transition(ChargerState.PoweredOff);
+    testStateMachine.transition(ChargerState.BootingUp);
+    testStateMachine.transition(ChargerState.Available);
+    testStateMachine.transition(ChargerState.Preparing);
+    testStateMachine.transition(ChargerState.Faulted);
+    assertEquals(
+        ChargerState.Faulted,
+        testStateMachine.getCurrentState(),
+        "Transition from Preparing to Faulted should be allowed");
+
+    // Transition from Charging to PoweredOff
+    testStateMachine.transition(ChargerState.PoweredOff);
+    testStateMachine.transition(ChargerState.BootingUp);
+    testStateMachine.transition(ChargerState.Available);
+    testStateMachine.transition(ChargerState.Preparing);
+    testStateMachine.transition(ChargerState.Charging);
+    testStateMachine.transition(ChargerState.Faulted);
+    assertEquals(
+        ChargerState.Faulted,
+        testStateMachine.getCurrentState(),
+        "Transition from Charging to Faulted should be allowed");
+  }
+
+  @Test
+  void testInvalidTransitionFromPoweredOff() {
+    // From PoweredOff, transitioning to Available is not allowed
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              testStateMachine.transition(ChargerState.Available);
+            });
+    assertTrue(
+        exception.getMessage().contains("Invalid state transition"),
+        "Expected an exception message indicating an invalid transition");
+  }
+
+  @Test
+  void testInvalidTransitionFromBootingUp() {
+    // From BootingUp, transitioning to Charging is not allowed
+    testStateMachine.transition(ChargerState.BootingUp);
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              testStateMachine.transition(ChargerState.Charging);
+            });
+    assertTrue(
+        exception.getMessage().contains("Invalid state transition"),
+        "Expected an exception message indicating an invalid transition");
+  }
+
+  @Test
+  void testInvalidTransitionFromAvailable() {
+    // From Available, transitioning back to BootingUp is not allowed
+    testStateMachine.transition(ChargerState.BootingUp);
+    testStateMachine.transition(ChargerState.Available);
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              testStateMachine.transition(ChargerState.BootingUp);
+            });
+    assertTrue(
+        exception.getMessage().contains("Invalid state transition"),
+        "Expected an exception message indicating an invalid transition");
+  }
+
+  @Test
+  void testInvalidTransitionFromPreparing() {
+    // From Preparing, transitioning to BootingUp is not allowed
+    testStateMachine.transition(ChargerState.BootingUp);
+    testStateMachine.transition(ChargerState.Available);
+    testStateMachine.transition(ChargerState.Preparing);
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              testStateMachine.transition(ChargerState.BootingUp);
+            });
+    assertTrue(
+        exception.getMessage().contains("Invalid state transition"),
+        "Expected an exception message indicating an invalid transition");
+  }
+
+  @Test
+  void testInvalidTransitionFromCharging() {
+    // From Charging, transitioning to BootingUp is not allowed
+    testStateMachine.transition(ChargerState.BootingUp);
+    testStateMachine.transition(ChargerState.Available);
+    testStateMachine.transition(ChargerState.Preparing);
+    testStateMachine.transition(ChargerState.Charging);
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              testStateMachine.transition(ChargerState.BootingUp);
+            });
+    assertTrue(
+        exception.getMessage().contains("Invalid state transition"),
+        "Expected an exception message indicating an invalid transition");
+  }
+
+  @Test
+  void testInvalidTransitionFromFaulted() {
+    // From Faulted, transitioning to Charging is not allowed
+    testStateMachine.transition(ChargerState.BootingUp);
+    testStateMachine.transition(ChargerState.Available);
+    testStateMachine.transition(ChargerState.Faulted);
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              testStateMachine.transition(ChargerState.Charging);
+            });
+    assertTrue(
+        exception.getMessage().contains("Invalid state transition"),
+        "Expected an exception message indicating an invalid transition");
   }
 }

--- a/backend/src/test/java/com/sim_backend/transactions/StartTransactionHandlerTest.java
+++ b/backend/src/test/java/com/sim_backend/transactions/StartTransactionHandlerTest.java
@@ -61,7 +61,7 @@ public class StartTransactionHandlerTest {
     handler.initiateStartTransaction(1, "Accepted", new AtomicInteger(), elec, new AtomicBoolean());
 
     verify(client).pushMessage(any(StartTransaction.class));
-    verify(stateMachine).transition(ChargerState.Charging);
+    verify(stateMachine).checkAndTransition(ChargerState.Preparing, ChargerState.Charging);
   }
 
   @Test
@@ -87,7 +87,7 @@ public class StartTransactionHandlerTest {
     verify(client).pushMessage(any(StartTransaction.class));
 
     // Verify that onTimeout() resulted in the state machine transitioning to Available
-    verify(stateMachine).transition(ChargerState.Available);
+    verify(stateMachine).checkAndTransition(ChargerState.Preparing, ChargerState.Available);
 
     // Verify that the startInProgress flag is set to false after the timeout
     assertFalse(startInProgress.get(), "startInProgress should be false after a timeout");

--- a/backend/src/test/java/com/sim_backend/transactions/TransactionHandlerTest.java
+++ b/backend/src/test/java/com/sim_backend/transactions/TransactionHandlerTest.java
@@ -1,8 +1,12 @@
 package com.sim_backend.transactions;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import com.sim_backend.charger.Charger;
@@ -13,10 +17,13 @@ import com.sim_backend.websockets.MessageScheduler;
 import com.sim_backend.websockets.OCPPTime;
 import com.sim_backend.websockets.OCPPWebSocketClient;
 import com.sim_backend.websockets.enums.AuthorizationStatus;
+import com.sim_backend.websockets.enums.Reason;
 import com.sim_backend.websockets.events.OnOCPPMessage;
 import com.sim_backend.websockets.events.OnOCPPMessageListener;
 import com.sim_backend.websockets.messages.*;
+import java.lang.reflect.Field;
 import java.time.ZonedDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -43,6 +50,7 @@ public class TransactionHandlerTest {
     when(scheduler.getTime()).thenReturn(ocppTime);
     when(ocppTime.getSynchronizedTime()).thenReturn(ZonedDateTime.parse("2025-01-19T00:00:00Z"));
     transactionHandler = new TransactionHandler(charger);
+    assertNotNull(transactionHandler.getTransactionId());
   }
 
   @Test
@@ -77,11 +85,11 @@ public class TransactionHandlerTest {
         .when(transactionHandler.getStartHandler().getClient())
         .onReceiveMessage(eq(StartTransactionResponse.class), any());
 
-    transactionHandler.preAuthorize(1, "Accepted");
+    transactionHandler.preAuthorize(1, "Accepted", null);
 
     verify(transactionHandler.getStartHandler().getClient()).pushMessage(any(Authorize.class));
     verify(transactionHandler.getStartHandler().getStateMachine())
-        .transition(ChargerState.Charging);
+        .checkAndTransition(ChargerState.Preparing, ChargerState.Charging);
     verify(transactionHandler.getStartHandler().getClient())
         .pushMessage(any(StartTransaction.class));
   }
@@ -90,6 +98,9 @@ public class TransactionHandlerTest {
   void PreAuthorizeStoptest() {
     when(transactionHandler.getStopHandler().getStateMachine().getCurrentState())
         .thenReturn(ChargerState.Charging);
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    when(stateMachine.checkAndTransition(ChargerState.Charging, ChargerState.Available))
+        .thenReturn(true);
 
     AuthorizeResponse authorizeResponse =
         new AuthorizeResponse(new AuthorizeResponse.IdTagInfo(AuthorizationStatus.ACCEPTED));
@@ -102,7 +113,7 @@ public class TransactionHandlerTest {
               listener.onMessageReceived(message);
               return null;
             })
-        .when(transactionHandler.getStartHandler().getClient())
+        .when(client)
         .onReceiveMessage(eq(AuthorizeResponse.class), any());
 
     StopTransactionResponse stopTransactionResponse = new StopTransactionResponse("Accepted");
@@ -118,11 +129,11 @@ public class TransactionHandlerTest {
         .when(transactionHandler.getStopHandler().getClient())
         .onReceiveMessage(eq(StopTransactionResponse.class), any());
 
-    transactionHandler.preAuthorize(1, "Accepted");
+    transactionHandler.preAuthorize(1, "Accepted", null);
 
     verify(transactionHandler.getStopHandler().getClient()).pushMessage(any(Authorize.class));
     verify(transactionHandler.getStopHandler().getStateMachine())
-        .transition(ChargerState.Available);
+        .checkAndTransition(ChargerState.Charging, ChargerState.Available);
     verify(transactionHandler.getStopHandler().getClient()).pushMessage(any(StopTransaction.class));
   }
 
@@ -143,9 +154,10 @@ public class TransactionHandlerTest {
         .when(client)
         .onReceiveMessage(eq(AuthorizeResponse.class), any());
 
-    transactionHandler.preAuthorize(1, "idTag");
+    transactionHandler.preAuthorize(1, "idTag", null);
 
-    verify(stateMachine, times(1)).transition(ChargerState.Available);
+    verify(stateMachine, times(1))
+        .checkAndTransition(ChargerState.Preparing, ChargerState.Available);
   }
 
   @Test
@@ -161,7 +173,7 @@ public class TransactionHandlerTest {
         .onReceiveMessage(eq(AuthorizeResponse.class), any());
 
     // Call preAuthorize() to initiate the process
-    transactionHandler.preAuthorize(1, "timeoutId");
+    transactionHandler.preAuthorize(1, "timeoutId", null);
 
     // Verify that an Authorize message was pushed
     verify(client).pushMessage(any(Authorize.class));
@@ -170,7 +182,7 @@ public class TransactionHandlerTest {
     verify(client).deleteOnReceiveMessage(eq(AuthorizeResponse.class), any());
 
     // Verify that the state machine transitions to Available on timeout
-    verify(stateMachine).transition(ChargerState.Available);
+    verify(stateMachine).checkAndTransition(ChargerState.Preparing, ChargerState.Available);
 
     // Verify that both startInProgress and stopInProgress flags are reset to false
     assertFalse(
@@ -179,5 +191,179 @@ public class TransactionHandlerTest {
     assertFalse(
         transactionHandler.getStopInProgress().get(),
         "stopInProgress should be false after a timeout");
+  }
+
+  @Test
+  void startChargingInvalidStateTest() {
+    // Test when the current state is not Available, startCharging does nothing
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    transactionHandler.startCharging(1, "testId");
+
+    // Verify no authorize message was pushed
+    verify(client, never()).pushMessage(any(Authorize.class));
+  }
+
+  @Test
+  void startChargingAlreadyInProgressTest() {
+    // Test when startCharging is already in progress, startCharging does nothing
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Available);
+    transactionHandler.getStartInProgress().set(true);
+    transactionHandler.startCharging(1, "testId");
+
+    // Verify no authorize message was pushed
+    verify(client, never()).pushMessage(any(Authorize.class));
+
+    transactionHandler.getStartInProgress().set(false);
+  }
+
+  @Test
+  void startChargingSuccessTest() {
+    // Test when the charger is Available, startCharging transitions to Preparing and triggers
+    // pre-authorization
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Available);
+    when(stateMachine.checkAndTransition(ChargerState.Available, ChargerState.Preparing))
+        .thenReturn(true);
+
+    TransactionHandler spyHandler = spy(transactionHandler);
+    doNothing().when(spyHandler).preAuthorize(anyInt(), anyString(), any());
+    spyHandler.startCharging(1, "testId");
+
+    // Verify that the state machine transitioned to Preparing
+    verify(stateMachine).checkAndTransition(ChargerState.Available, ChargerState.Preparing);
+
+    // Verify that preAuthorize() was called with the correct parameters
+    verify(spyHandler).preAuthorize(eq(1), eq("testId"), isNull());
+  }
+
+  @Test
+  void stopChargingInvalidStateTest() {
+    // Test when the current state is not Charging, stopCharging does nothing
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Available);
+    transactionHandler.stopCharging("testId", Reason.LOCAL);
+
+    // Verify no authorize message was pushed
+    verify(client, never()).pushMessage(any(Authorize.class));
+  }
+
+  @Test
+  void stopChargingAlreadyInProgressTest() {
+    // Test when stopCharging is already in progress, stopCharging does nothing
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    transactionHandler.getStopInProgress().set(true);
+    transactionHandler.stopCharging("testId", Reason.LOCAL);
+
+    // Verify no authorize message was pushed
+    verify(client, never()).pushMessage(any(Authorize.class));
+
+    transactionHandler.getStopInProgress().set(false);
+  }
+
+  @Test
+  void stopChargingDirectStopTest() throws Exception {
+    // Test when the provided idTag matches the current authorized idTag, stopCharging triggers a
+    // direct stop
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    transactionHandler.getStopInProgress().set(false);
+
+    Field idTagField = TransactionHandler.class.getDeclaredField("idTag");
+    idTagField.setAccessible(true);
+    idTagField.set(transactionHandler, "testId");
+
+    // Spy on the stopHandler to verify that its initiateStopTransaction() is called
+    Object originalStopHandler = transactionHandler.getStopHandler();
+    StopTransactionHandler spiedStopHandler = spy((StopTransactionHandler) originalStopHandler);
+    Field stopHandlerField = TransactionHandler.class.getDeclaredField("stopHandler");
+    stopHandlerField.setAccessible(true);
+    stopHandlerField.set(transactionHandler, spiedStopHandler);
+
+    transactionHandler.stopCharging("testId", Reason.LOCAL);
+    // Verify that initiateStopTransaction() was called on the stop handler with the expected
+    // parameters
+    verify(spiedStopHandler)
+        .initiateStopTransaction(
+            eq("testId"), eq(Reason.LOCAL), any(AtomicInteger.class), eq(elec), any());
+  }
+
+  @Test
+  void stopChargingPreAuthorizeTest() {
+    // Test when the provided idTag does not match the current authorized idTag, stopCharging
+    // triggers pre-authorization
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    Field idTagField;
+    try {
+      idTagField = TransactionHandler.class.getDeclaredField("idTag");
+      idTagField.setAccessible(true);
+      idTagField.set(transactionHandler, "authorizedId");
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    TransactionHandler spyHandler = spy(transactionHandler);
+
+    doNothing().when(spyHandler).preAuthorize(anyInt(), anyString(), any());
+    spyHandler.stopCharging("differentId", Reason.LOCAL);
+
+    // Verify that preAuthorize() was called with connectorId = -1 and the correct idTag and
+    // reason
+    verify(spyHandler).preAuthorize(eq(-1), eq("differentId"), eq(Reason.LOCAL));
+  }
+
+  @Test
+  void forceStopChargingSuccessTest() throws Exception {
+    // Test when the charger is in Charging state and transactionId is valid, forceStopCharging
+    // triggers a stop
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    transactionHandler.getTransactionId().set(100);
+
+    // py on the stopHandler to verify that its initiateStopTransaction() is called
+    Object originalStopHandler = transactionHandler.getStopHandler();
+    StopTransactionHandler spiedStopHandler = spy((StopTransactionHandler) originalStopHandler);
+    Field stopHandlerField = TransactionHandler.class.getDeclaredField("stopHandler");
+    stopHandlerField.setAccessible(true);
+    stopHandlerField.set(transactionHandler, spiedStopHandler);
+
+    // Ensure stopInProgress is false
+    transactionHandler.getStopInProgress().set(false);
+    transactionHandler.forceStopCharging(Reason.LOCAL);
+
+    // Verify that initiateStopTransaction() was called on the stop handler with a null idTag
+    verify(spiedStopHandler)
+        .initiateStopTransaction(
+            isNull(), eq(Reason.LOCAL), any(AtomicInteger.class), eq(elec), any());
+  }
+
+  @Test
+  void forceStopChargingNoActionTest() throws Exception {
+    // Test when the state is not Charging or Faulted, forceStopCharging does nothing
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Available);
+    transactionHandler.getTransactionId().set(100);
+    transactionHandler.getStopInProgress().set(false);
+    transactionHandler.forceStopCharging(Reason.LOCAL);
+
+    // Spy on the stopHandler to verify that no stop transaction was initiated
+    Object originalStopHandler = transactionHandler.getStopHandler();
+    StopTransactionHandler spiedStopHandler = spy((StopTransactionHandler) originalStopHandler);
+    Field stopHandlerField = TransactionHandler.class.getDeclaredField("stopHandler");
+    stopHandlerField.setAccessible(true);
+    stopHandlerField.set(transactionHandler, spiedStopHandler);
+
+    // Verify no stop transaction was initiated
+    verify(spiedStopHandler, never()).initiateStopTransaction(any(), any(), any(), any(), any());
+
+    // Test when transactionId is -1, forceStopCharging does nothing
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    transactionHandler.getTransactionId().set(-1);
+    transactionHandler.forceStopCharging(Reason.LOCAL);
+
+    // Verify no stop transaction was initiated
+    verify(spiedStopHandler, never()).initiateStopTransaction(any(), any(), any(), any(), any());
+
+    // Test when stopInProgress is true, forceStopCharging does nothing
+    when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
+    transactionHandler.getTransactionId().set(100);
+    transactionHandler.getStopInProgress().set(true);
+    transactionHandler.forceStopCharging(Reason.LOCAL);
+
+    // Verify no stop transaction was initiated
+    verify(spiedStopHandler, never()).initiateStopTransaction(any(), any(), any(), any(), any());
   }
 }

--- a/backend/src/test/java/com/sim_backend/websockets/messages/StopTransactionTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/StopTransactionTest.java
@@ -4,6 +4,7 @@ import com.networknt.schema.InputFormat;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.ValidationMessage;
 import com.sim_backend.websockets.GsonUtilities;
+import com.sim_backend.websockets.enums.Reason;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test;
 public class StopTransactionTest {
 
   private static @NotNull StopTransaction getStopTransaction() {
-    // Create an StopTransaction request
+    // Create a StopTransaction request
     StopTransaction stopTransaction = new StopTransaction("tag", 1, 10, "2025-01-01T00:00:00Z");
 
     assert stopTransaction.getIdTag() == "tag";
@@ -41,6 +42,42 @@ public class StopTransactionTest {
     // Check expected message structure
     assert message.equals(
         "{\"idTag\":\"tag\",\"transactionId\":1,\"meterStop\":10,\"timestamp\":\"2025-01-01T00:00:00Z\"}");
+    assert errors.isEmpty();
+  }
+
+  private @NotNull StopTransaction getStopTransactionWithReasonNoTag() {
+    // Create a StopTransaction request with the reason field populated
+    StopTransaction stopTransaction =
+        new StopTransaction(1, 10, "2025-01-01T00:00:00Z", Reason.EMERGENCY_STOP);
+
+    assert stopTransaction.getTransactionId() == 1;
+    assert stopTransaction.getMeterStop() == 10;
+    assert stopTransaction.getTimestamp().equals("2025-01-01T00:00:00Z");
+    assert stopTransaction.getReason().equals(Reason.EMERGENCY_STOP);
+    return stopTransaction;
+  }
+
+  @Test
+  public void testStopTransactionWithReasonNoTag() {
+    StopTransaction request = getStopTransactionWithReasonNoTag();
+
+    // Ensure message generation works
+    assert request.generateMessage().size() == 4;
+    String message = GsonUtilities.toString(request.generateMessage().get(3));
+
+    // Validate against schema
+    JsonSchema jsonSchema = JsonSchemaHelper.getJsonSchema("schemas/StopTransaction.json");
+    Set<ValidationMessage> errors = jsonSchema.validate(message, InputFormat.JSON);
+
+    if (!errors.isEmpty()) {
+      for (ValidationMessage error : errors) {
+        System.out.println(error);
+      }
+    }
+
+    // Check expected message structure
+    assert message.equals(
+        "{\"transactionId\":1,\"meterStop\":10,\"timestamp\":\"2025-01-01T00:00:00Z\",\"reason\":\"EmergencyStop\"}");
     assert errors.isEmpty();
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -29,13 +29,15 @@ function App() {
 
   return (
     <div>
-      <h1>OCPP Charger Simulator</h1>
-      {status === 'failure' && (
-        <b data-testid="message">
-          ERROR: Backend at {process.env.REACT_APP_BACKEND_URL} was not
-          reachable
-        </b>
-      )}
+      <div className="header-container">
+        <h1>OCPP Charger Simulator</h1>
+        {status === 'failure' && (
+          <b data-testid="message">
+            ERROR: Backend at {process.env.REACT_APP_BACKEND_URL} was not
+            reachable
+          </b>
+        )}
+      </div>
       <div className="charger-frames-container">
         {[1, 2, 3].map((id) => (
           <div key={id} className="charger-container">

--- a/frontend/src/components/ChargerFrame.js
+++ b/frontend/src/components/ChargerFrame.js
@@ -5,6 +5,7 @@ import ChargingButton from './buttons/ChargingButton';
 import '../styles/styles.css';
 import { pollChargerData } from './ChargerLabels';
 import RebootButton from './buttons/RebootButton';
+import ErrorMenu from './ErrorMenu';
 import ConfigGear from './ConfigIdTagUrl';
 import PropTypes from 'prop-types';
 
@@ -62,6 +63,7 @@ function ChargerFrame({ chargerID }) {
       <div className="config-button-container">
         <ConfigGear chargerID={chargerID} />
       </div>
+      <ErrorMenu chargerID={chargerID} />
     </div>
   );
 }

--- a/frontend/src/components/ErrorMenu.js
+++ b/frontend/src/components/ErrorMenu.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import '../styles/styles.css';
 
 const errorCodes = [
@@ -20,18 +21,6 @@ const errorCodes = [
   'WeakSignal',
 ];
 
-const statusOptions = [
-  'Available',
-  'Preparing',
-  'Charging',
-  'SuspendedEVSE',
-  'SuspendedEV',
-  'Finishing',
-  'Faulted',
-  'Unavailable',
-  'Reserved',
-];
-
 const ErrorMenu = ({ chargerID }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
@@ -42,7 +31,6 @@ const ErrorMenu = ({ chargerID }) => {
   const [connectorId, setConnectorId] = useState('1');
   const [errorCode, setErrorCode] = useState('');
   const [info, setInfo] = useState('');
-  const [status, setStatus] = useState('');
   const [vendorId, setVendorId] = useState('');
   const [vendorErrorCode, setVendorErrorCode] = useState('');
 
@@ -61,7 +49,6 @@ const ErrorMenu = ({ chargerID }) => {
     setConnectorId('1');
     setErrorCode('');
     setInfo('');
-    setStatus('');
     setVendorId('');
     setVendorErrorCode('');
     setUseCurrentTimestamp(false);
@@ -79,7 +66,6 @@ const ErrorMenu = ({ chargerID }) => {
     let payload = {
       connectorId,
       errorCode,
-      status,
     };
 
     // Conditionally add optional fields
@@ -178,21 +164,6 @@ const ErrorMenu = ({ chargerID }) => {
               </div>
 
               <div className="form-item">
-                <label>Status (required):</label>
-                <select
-                  value={status}
-                  onChange={(e) => setStatus(e.target.value)}
-                >
-                  <option value="">select a status </option>
-                  {statusOptions.map((status) => (
-                    <option key={status} value={status}>
-                      {status}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div className="form-item">
                 <label>
                   <input
                     type="checkbox"
@@ -237,6 +208,10 @@ const ErrorMenu = ({ chargerID }) => {
       )}
     </div>
   );
+};
+
+ErrorMenu.propTypes = {
+  chargerID: PropTypes.number.isRequired, // 'chargerID' should be a number
 };
 
 export default ErrorMenu;

--- a/frontend/src/components/ShowLogMessage.js
+++ b/frontend/src/components/ShowLogMessage.js
@@ -222,8 +222,8 @@ const ShowLogMessages = ({ chargerID }) => {
     fetchData(); // Fetch once when the component mounts
 
     const interval = setInterval(() => {
-      fetchData(); // Refetch every 10 seconds (or set your preferred interval)
-    }, 10000);
+      fetchData(); // Refetch every 5 seconds
+    }, 5000);
 
     return interval;
   };

--- a/frontend/src/components/buttons/ChargingButton.js
+++ b/frontend/src/components/buttons/ChargingButton.js
@@ -11,6 +11,9 @@ class ChargingButtonLogic extends ButtonBase {
     } else if (stateValue.includes('Available')) {
       // If available, offer to start charging
       super('Start Charging', `/api/${chargerID}/transaction/start-charge`);
+    } else if (stateValue.includes('Faulted')) {
+      // If Faulted, offer to clear the fault
+      super('Clear Fault', `/api/${chargerID}/charger/clear-fault`);
     } else {
       super('Unavailable', '');
     }
@@ -18,10 +21,12 @@ class ChargingButtonLogic extends ButtonBase {
 }
 
 const ChargingButton = ({ chargerID, stateValue }) => {
-  // Hide the button if the state is neither "Charging" nor "Available"
+  // Hide the button if the state is not "Charging", "Available" or "Faulted"
   if (
     !stateValue ||
-    (!stateValue.includes('Charging') && !stateValue.includes('Available'))
+    (!stateValue.includes('Charging') &&
+      !stateValue.includes('Available') &&
+      !stateValue.includes('Faulted'))
   ) {
     return null;
   }

--- a/frontend/src/styles/styles.css
+++ b/frontend/src/styles/styles.css
@@ -57,6 +57,17 @@ h1 {
   flex: 1;
   box-sizing: border-box;
 }
+
+.header-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-container h1 {
+  margin: 10px;
+}
+
 /* =====================================================
    ChargerFrame Component & Sub-Components Styles
    ===================================================== */
@@ -218,7 +229,7 @@ button:active {
   border: 1px solid var(--neutral-grey);
   border-radius: 8px;
   padding: 10px;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   background-color: var(--background-white);
   box-shadow: 0 4px 8px var(--shadow-color);
   user-select: text;
@@ -226,7 +237,7 @@ button:active {
 
 /* Header with timestamp, request type, and NumId label */
 .log-message-header {
-  margin-bottom: 10px;
+  margin-bottom: 0px;
   display: flex;
   align-items: center;
   gap: 10px; /* Space between elements */
@@ -408,7 +419,6 @@ button:active {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: 20px;
 }
 
 /* Button to open the modal */


### PR DESCRIPTION
This PR adds the faulted state to our simulator. A status request from the frontend will cause the simulator to enter this faulted state. The user can click "Clear Fault" in the frontend to return to an available state.

Since this allows a thread to make a state transition at almost any time, it became necessary to make an atomic version of the state transition function. This is used in areas where the validity of a regular state transition is not guaranteed.

This PR also adds the optional `reason` field to `StopTransaction` messages. These are used when a simulated fault or reboot stops a transaction.

There are also various fixes for transaction related edge cases.