### PR TITLE
CSCAP 189, Responses have random IDs

### DIFF
--- a/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/AuthorizeResponse.java
@@ -16,7 +16,6 @@ import lombok.Setter;
  * status of a Charge Point's idTag.
  */
 @EqualsAndHashCode(callSuper = true)
-@AllArgsConstructor
 @Getter
 @Setter
 @OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_RESPONSE, messageName = "AuthorizeResponse")
@@ -35,7 +34,13 @@ public class AuthorizeResponse extends OCPPMessageResponse implements Cloneable 
     private AuthorizationStatus status; // One of: Accepted, Blocked, Expired, Invalid, ConcurrentTx
   }
 
-  public AuthorizeResponse(String status) {
+  public AuthorizeResponse(Authorize request, IdTagInfo info) {
+    super(request);
+    this.idTagInfo = info;
+  }
+
+  public AuthorizeResponse(Authorize request, String status) {
+    super(request);
     this.idTagInfo = new IdTagInfo(AuthorizationStatus.fromString(status));
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/BootNotificationResponse.java
@@ -7,7 +7,6 @@ import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
 import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,7 +17,6 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-@AllArgsConstructor
 @OCPPMessageInfo(
     messageCallID = OCPPMessage.CALL_ID_RESPONSE,
     messageName = "BootNotificationResponse")
@@ -40,8 +38,21 @@ public class BootNotificationResponse extends OCPPMessageResponse implements Clo
   @SerializedName("interval")
   private int interval;
 
-  public BootNotificationResponse(String status, ZonedDateTime currentTime, int interval) {
+  public BootNotificationResponse(
+      BootNotification request, String status, ZonedDateTime currentTime, int interval) {
+    super(request);
     this.status = RegistrationStatus.fromString(status);
+    this.currentTime = currentTime;
+    this.interval = interval;
+  }
+
+  public BootNotificationResponse(
+      BootNotification request,
+      RegistrationStatus status,
+      ZonedDateTime currentTime,
+      int interval) {
+    super(request);
+    this.status = status;
     this.currentTime = currentTime;
     this.interval = interval;
   }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/ChangeConfigurationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/ChangeConfigurationResponse.java
@@ -6,7 +6,6 @@ import com.sim_backend.websockets.enums.ConfigurationStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,7 +14,6 @@ import lombok.Setter;
  * Represents an OCPP 1.6 ChangeConfiguration Response from a Charge Point to the Central System to
  * confirm the key
  */
-@AllArgsConstructor
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
@@ -27,7 +25,8 @@ public class ChangeConfigurationResponse extends OCPPMessageResponse implements 
   @SerializedName("status")
   private ConfigurationStatus status; // Accepted, NotSupported, Rejected
 
-  public ChangeConfigurationResponse(String status) {
+  public ChangeConfigurationResponse(ChangeConfiguration request, String status) {
+    super(request);
     this.status = ConfigurationStatus.fromString(status);
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/ClearChargingProfileResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/ClearChargingProfileResponse.java
@@ -10,18 +10,20 @@ import com.sim_backend.websockets.enums.ClearProfileStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
 import com.sim_backend.websockets.types.OCPPMessageResponse;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /** A OCPP Clear Charging Profile Response Message. */
-@AllArgsConstructor
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @OCPPMessageInfo(
     messageCallID = OCPPMessage.CALL_ID_RESPONSE,
     messageName = "ClearChargingProfileResponse")
 public final class ClearChargingProfileResponse extends OCPPMessageResponse {
+  public ClearChargingProfileResponse(ClearChargingProfile request, ClearProfileStatus status) {
+    super(request);
+    this.status = status;
+  }
 
   /** The status of the clear charging profile request. */
   @SerializedName("status")

--- a/backend/src/main/java/com/sim_backend/websockets/messages/GetConfigurationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/GetConfigurationResponse.java
@@ -13,12 +13,18 @@ import lombok.Setter;
 
 /** Represents an OCPP 1.6 GetConfiguration Request from Central System to a Charge Point */
 @Getter
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @OCPPMessageInfo(
     messageCallID = OCPPMessage.CALL_ID_RESPONSE,
     messageName = "GetConfigurationResponse")
 public class GetConfigurationResponse extends OCPPMessageResponse implements Cloneable {
+  public GetConfigurationResponse(
+      GetConfiguration request, List<Configuration> configurationKeys, List<String> unknownKey) {
+    super(request);
+    this.configurationKey = configurationKeys;
+    this.unknownKey = unknownKey;
+  }
+
   @SerializedName("configurationKey")
   private final List<Configuration> configurationKey;
 

--- a/backend/src/main/java/com/sim_backend/websockets/messages/HeartbeatResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/HeartbeatResponse.java
@@ -7,7 +7,6 @@ import com.sim_backend.websockets.types.OCPPMessageResponse;
 import jakarta.validation.constraints.NotBlank;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -15,7 +14,6 @@ import lombok.Getter;
  * Represents an OCPP 1.6 Heartbeat Response sent by the Central System to acknowledge a Heartbeat
  * Request and provide the current server time.
  */
-@AllArgsConstructor
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_RESPONSE, messageName = "HeartbeatResponse")
@@ -27,9 +25,14 @@ public final class HeartbeatResponse extends OCPPMessageResponse implements Clon
   private final ZonedDateTime currentTime;
 
   /** The response message for a Heartbeat, currentTime will be set to now. */
-  public HeartbeatResponse() {
-    super();
+  public HeartbeatResponse(Heartbeat request) {
+    super(request);
     this.currentTime = ZonedDateTime.now(ZoneId.of("UTC"));
+  }
+
+  public HeartbeatResponse(Heartbeat request, ZonedDateTime currentTime) {
+    super(request);
+    this.currentTime = currentTime;
   }
 
   @Override

--- a/backend/src/main/java/com/sim_backend/websockets/messages/SetChargingProfile.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/SetChargingProfile.java
@@ -7,6 +7,7 @@ import com.sim_backend.websockets.enums.ChargingProfilePurpose;
 import com.sim_backend.websockets.enums.ChargingRateUnit;
 import com.sim_backend.websockets.enums.RecurrencyKind;
 import com.sim_backend.websockets.types.OCPPMessage;
+import com.sim_backend.websockets.types.OCPPMessageRequest;
 import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -17,7 +18,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @OCPPMessageInfo(messageCallID = OCPPMessage.CALL_ID_REQUEST, messageName = "SetChargingProfile")
-public class SetChargingProfile {
+public class SetChargingProfile extends OCPPMessageRequest {
 
   /** The ID of the connector to which the profile applies. */
   @NotNull(message = "SetChargingProfile connectorId is required")

--- a/backend/src/main/java/com/sim_backend/websockets/messages/SetChargingProfileResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/SetChargingProfileResponse.java
@@ -3,19 +3,22 @@ package com.sim_backend.websockets.messages;
 import com.sim_backend.websockets.annotations.OCPPMessageInfo;
 import com.sim_backend.websockets.enums.ChargingProfileStatus;
 import com.sim_backend.websockets.types.OCPPMessage;
+import com.sim_backend.websockets.types.OCPPMessageResponse;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /** Represents a response for setting a charging profile. */
 @Getter
-@AllArgsConstructor
 @OCPPMessageInfo(
     messageCallID = OCPPMessage.CALL_ID_RESPONSE,
     messageName = "SetChargingProfileResponse")
-public class SetChargingProfileResponse {
+public class SetChargingProfileResponse extends OCPPMessageResponse {
+  public SetChargingProfileResponse(SetChargingProfile profile, ChargingProfileStatus status) {
+    super(profile);
+    this.status = status;
+  }
 
   /** The status of the charging profile response. */
   @NotNull(message = "SetChargingProfileResponse status is required and cannot be blank")
-  private ChargingProfileStatus status;
+  private final ChargingProfileStatus status;
 }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StartTransactionResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StartTransactionResponse.java
@@ -39,7 +39,8 @@ public class StartTransactionResponse extends OCPPMessageResponse implements Clo
   }
 
   // Constructor
-  public StartTransactionResponse(int transactionId, String idTagInfo) {
+  public StartTransactionResponse(StartTransaction request, int transactionId, String idTagInfo) {
+    super(request);
     this.transactionId = transactionId;
     this.idTagInfo = new idTagInfo(AuthorizationStatus.fromString(idTagInfo));
   }

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StatusNotificationResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StatusNotificationResponse.java
@@ -15,6 +15,9 @@ import lombok.EqualsAndHashCode;
     messageName = "StatusNotificationResponse")
 public class StatusNotificationResponse extends OCPPMessageResponse implements Cloneable {
   // No fields are defined as per the protocol specification
+  public StatusNotificationResponse(StatusNotification request) {
+    super(request);
+  }
 
   @Override
   protected StatusNotificationResponse clone() {

--- a/backend/src/main/java/com/sim_backend/websockets/messages/StopTransactionResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/messages/StopTransactionResponse.java
@@ -36,7 +36,8 @@ public class StopTransactionResponse extends OCPPMessageResponse implements Clon
   }
 
   // Constructor
-  public StopTransactionResponse(String idTagInfo) {
+  public StopTransactionResponse(StopTransaction request, String idTagInfo) {
+    super(request);
     this.idTagInfo = new idTagInfo(AuthorizationStatus.fromString(idTagInfo));
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/observers/ChangeConfigurationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/ChangeConfigurationObserver.java
@@ -79,7 +79,7 @@ public class ChangeConfigurationObserver implements OnOCPPMessageListener {
     }
 
     ChangeConfigurationResponse response = new ChangeConfigurationResponse(status);
-
+    response.setMessageID(request.getMessageID());
     if (!MessageValidator.isValid(response)) {
       throw new IllegalArgumentException(MessageValidator.log_message(response));
     } else {

--- a/backend/src/main/java/com/sim_backend/websockets/observers/ChangeConfigurationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/ChangeConfigurationObserver.java
@@ -78,8 +78,7 @@ public class ChangeConfigurationObserver implements OnOCPPMessageListener {
         break;
     }
 
-    ChangeConfigurationResponse response = new ChangeConfigurationResponse(status);
-    response.setMessageID(request.getMessageID());
+    ChangeConfigurationResponse response = new ChangeConfigurationResponse(request, status);
     if (!MessageValidator.isValid(response)) {
       throw new IllegalArgumentException(MessageValidator.log_message(response));
     } else {

--- a/backend/src/main/java/com/sim_backend/websockets/observers/GetConfigurationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/GetConfigurationObserver.java
@@ -86,6 +86,7 @@ public class GetConfigurationObserver implements OnOCPPMessageListener {
 
     GetConfigurationResponse response =
         new GetConfigurationResponse(configurationInfo, unknownKeys);
+    response.setMessageID(request.getMessageID());
 
     if (!MessageValidator.isValid(response)) {
       throw new IllegalArgumentException(MessageValidator.log_message(response));

--- a/backend/src/main/java/com/sim_backend/websockets/observers/GetConfigurationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/GetConfigurationObserver.java
@@ -85,8 +85,7 @@ public class GetConfigurationObserver implements OnOCPPMessageListener {
     }
 
     GetConfigurationResponse response =
-        new GetConfigurationResponse(configurationInfo, unknownKeys);
-    response.setMessageID(request.getMessageID());
+        new GetConfigurationResponse(request, configurationInfo, unknownKeys);
 
     if (!MessageValidator.isValid(response)) {
       throw new IllegalArgumentException(MessageValidator.log_message(response));

--- a/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessage.java
@@ -43,7 +43,7 @@ public abstract class OCPPMessage implements Cloneable {
    * @param messageID The wanted message ID.
    */
   protected OCPPMessage(String messageID) {
-    this.messageID = generateMessageID();
+    this.messageID = messageID;
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessage.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessage.java
@@ -38,6 +38,15 @@ public abstract class OCPPMessage implements Cloneable {
   }
 
   /**
+   * The constructor for an OCPP message given a wanted message id.
+   *
+   * @param messageID The wanted message ID.
+   */
+  protected OCPPMessage(String messageID) {
+    this.messageID = generateMessageID();
+  }
+
+  /**
    * Create a JSON element representing the message.
    *
    * @return The generated message JSON.

--- a/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessageResponse.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/OCPPMessageResponse.java
@@ -10,6 +10,11 @@ import lombok.extern.slf4j.Slf4j;
 @EqualsAndHashCode(callSuper = true)
 @Slf4j
 public class OCPPMessageResponse extends OCPPMessage implements Cloneable {
+
+  public OCPPMessageResponse(OCPPMessageRequest request) {
+    super(request.getMessageID());
+  }
+
   /**
    * Define the structure for a request message.
    *

--- a/backend/src/test/java/com/sim_backend/transactions/StartTransactionHandlerTest.java
+++ b/backend/src/test/java/com/sim_backend/transactions/StartTransactionHandlerTest.java
@@ -45,7 +45,8 @@ public class StartTransactionHandlerTest {
   void initiateStartTransactiontest() {
     when(stateMachine.getCurrentState()).thenReturn(ChargerState.Preparing);
 
-    StartTransactionResponse startTransactionResponse = new StartTransactionResponse(1, "Accepted");
+    StartTransactionResponse startTransactionResponse =
+        new StartTransactionResponse(new StartTransaction(1, "", 1, ""), 1, "Accepted");
 
     doAnswer(
             invocation -> {

--- a/backend/src/test/java/com/sim_backend/transactions/StopTransactionHandlerTest.java
+++ b/backend/src/test/java/com/sim_backend/transactions/StopTransactionHandlerTest.java
@@ -42,7 +42,8 @@ public class StopTransactionHandlerTest {
   @Test
   void initiateStopTransactiontest() {
     when(stateMachine.getCurrentState()).thenReturn(ChargerState.Charging);
-    StopTransactionResponse stopTransactionResponse = new StopTransactionResponse("Accepted");
+    StopTransactionResponse stopTransactionResponse =
+        new StopTransactionResponse(new StopTransaction("", 1, 1, ""), "Accepted");
 
     doAnswer(
             invocation -> {

--- a/backend/src/test/java/com/sim_backend/transactions/TransactionHandlerTest.java
+++ b/backend/src/test/java/com/sim_backend/transactions/TransactionHandlerTest.java
@@ -51,7 +51,8 @@ public class TransactionHandlerTest {
         .thenReturn(ChargerState.Preparing);
 
     AuthorizeResponse authorizeResponse =
-        new AuthorizeResponse(new AuthorizeResponse.IdTagInfo(AuthorizationStatus.ACCEPTED));
+        new AuthorizeResponse(
+            new Authorize(), new AuthorizeResponse.IdTagInfo(AuthorizationStatus.ACCEPTED));
 
     doAnswer(
             invocation -> {
@@ -64,7 +65,8 @@ public class TransactionHandlerTest {
         .when(transactionHandler.getStartHandler().getClient())
         .onReceiveMessage(eq(AuthorizeResponse.class), any());
 
-    StartTransactionResponse startTransactionResponse = new StartTransactionResponse(1, "Accepted");
+    StartTransactionResponse startTransactionResponse =
+        new StartTransactionResponse(new StartTransaction(1, "", 1, ""), 1, "Accepted");
 
     doAnswer(
             invocation -> {
@@ -92,7 +94,8 @@ public class TransactionHandlerTest {
         .thenReturn(ChargerState.Charging);
 
     AuthorizeResponse authorizeResponse =
-        new AuthorizeResponse(new AuthorizeResponse.IdTagInfo(AuthorizationStatus.ACCEPTED));
+        new AuthorizeResponse(
+            new Authorize(), new AuthorizeResponse.IdTagInfo(AuthorizationStatus.ACCEPTED));
 
     doAnswer(
             invocation -> {
@@ -105,7 +108,8 @@ public class TransactionHandlerTest {
         .when(transactionHandler.getStartHandler().getClient())
         .onReceiveMessage(eq(AuthorizeResponse.class), any());
 
-    StopTransactionResponse stopTransactionResponse = new StopTransactionResponse("Accepted");
+    StopTransactionResponse stopTransactionResponse =
+        new StopTransactionResponse(new StopTransaction("", 1, 1, ""), "Accepted");
 
     doAnswer(
             invocation -> {
@@ -130,7 +134,8 @@ public class TransactionHandlerTest {
   void PreAuthorizeDeniedtest() {
 
     AuthorizeResponse authorizeResponse =
-        new AuthorizeResponse(new AuthorizeResponse.IdTagInfo(AuthorizationStatus.BLOCKED));
+        new AuthorizeResponse(
+            new Authorize(), new AuthorizeResponse.IdTagInfo(AuthorizationStatus.BLOCKED));
 
     doAnswer(
             invocation -> {

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPMessageTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPMessageTest.java
@@ -33,7 +33,7 @@ public class OCPPMessageTest {
 
   @Test
   void testClone() {
-    HeartbeatResponse res1 = new HeartbeatResponse(ZonedDateTime.now());
+    HeartbeatResponse res1 = new HeartbeatResponse(new Heartbeat(), ZonedDateTime.now());
     HeartbeatResponse res2 = (HeartbeatResponse) res1.cloneMessage();
     assertEquals(res1.getCurrentTime(), res2.getCurrentTime());
 
@@ -44,7 +44,8 @@ public class OCPPMessageTest {
     assertEquals(3, stopTrans2.getMeterStop());
     assertEquals("Whe", stopTrans2.getTimestamp());
 
-    StopTransactionResponse stopTransRes1 = new StopTransactionResponse("Accepted");
+    StopTransactionResponse stopTransRes1 =
+        new StopTransactionResponse(new StopTransaction("b", 1, 1, "a"), "Accepted");
     StopTransactionResponse stopTransRes2 = (StopTransactionResponse) stopTransRes1.cloneMessage();
     assertEquals(AuthorizationStatus.ACCEPTED, stopTransRes2.getIdTagInfo().getStatus());
   }

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPTimeTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPTimeTest.java
@@ -9,6 +9,7 @@ import com.sim_backend.websockets.enums.ErrorCode;
 import com.sim_backend.websockets.events.OnOCPPMessage;
 import com.sim_backend.websockets.events.OnOCPPMessageListener;
 import com.sim_backend.websockets.exceptions.OCPPMessageFailure;
+import com.sim_backend.websockets.messages.Heartbeat;
 import com.sim_backend.websockets.messages.HeartbeatResponse;
 import com.sim_backend.websockets.types.OCPPMessageError;
 import com.sim_backend.websockets.types.OCPPRepeatingTimedTask;
@@ -43,7 +44,8 @@ public class OCPPTimeTest {
   @Test
   public void testOCPPTime() throws InterruptedException, OCPPMessageFailure {
     doNothing().when(client).send(anyString());
-    HeartbeatResponse response = new HeartbeatResponse(ZonedDateTime.now().minusSeconds(24));
+    HeartbeatResponse response =
+        new HeartbeatResponse(new Heartbeat(), ZonedDateTime.now().minusSeconds(24));
 
     ocppTime.setHeartbeatInterval(20L, TimeUnit.SECONDS);
     ocppTime.heartbeat.task.run();
@@ -165,7 +167,8 @@ public class OCPPTimeTest {
     doNothing().when(client).send(anyString());
     OCPPTime spyTime = spy(client.getScheduler().getTime());
 
-    HeartbeatResponse heartbeatResponse = new HeartbeatResponse(ZonedDateTime.now());
+    HeartbeatResponse heartbeatResponse =
+        new HeartbeatResponse(new Heartbeat(), ZonedDateTime.now());
 
     OCPPRepeatingTimedTask heartbeat = ocppTime.setHeartbeatInterval(20L, TimeUnit.SECONDS);
     heartbeatResponse.setMessageID(heartbeat.getMessage().getMessageID());

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -812,4 +812,18 @@ public class OCPPWebSocketClientTest {
     field.setAccessible(true);
     return field;
   }
+
+  @Test
+  public void testUniqueIDs() throws Exception {
+      doAnswer(invocation -> null).when(client).send(anyString());
+      Heartbeat beat = new Heartbeat();
+      client.handleMessage(beat.toJsonString());
+      client.handleMessage(beat.toJsonString());
+
+      OCPPMessageError error = (OCPPMessageError) client.popMessage();
+      assertNotNull(error);
+      assertEquals(ErrorCode.OccurenceConstraintViolation, error.getErrorCode());
+      assertEquals("ID was already used", error.getErrorDescription());
+      assertEquals(error.getMessageID(), beat.getMessageID());
+  }
 }

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -815,15 +815,15 @@ public class OCPPWebSocketClientTest {
 
   @Test
   public void testUniqueIDs() throws Exception {
-      doAnswer(invocation -> null).when(client).send(anyString());
-      Heartbeat beat = new Heartbeat();
-      client.handleMessage(beat.toJsonString());
-      client.handleMessage(beat.toJsonString());
+    doAnswer(invocation -> null).when(client).send(anyString());
+    Heartbeat beat = new Heartbeat();
+    client.handleMessage(beat.toJsonString());
+    client.handleMessage(beat.toJsonString());
 
-      OCPPMessageError error = (OCPPMessageError) client.popMessage();
-      assertNotNull(error);
-      assertEquals(ErrorCode.OccurenceConstraintViolation, error.getErrorCode());
-      assertEquals("ID was already used", error.getErrorDescription());
-      assertEquals(error.getMessageID(), beat.getMessageID());
+    OCPPMessageError error = (OCPPMessageError) client.popMessage();
+    assertNotNull(error);
+    assertEquals(ErrorCode.OccurenceConstraintViolation, error.getErrorCode());
+    assertEquals("ID was already used", error.getErrorDescription());
+    assertEquals(error.getMessageID(), beat.getMessageID());
   }
 }

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -686,7 +686,7 @@ public class OCPPWebSocketClientTest {
     assertThrows(
         OCPPBadCallID.class,
         () -> {
-          client.handleMessage("[5,\"w\", \"Heartbeat\", {}]");
+          client.handleMessage("[5,\"w0\", \"Heartbeat\", {}]");
         });
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
@@ -694,77 +694,80 @@ public class OCPPWebSocketClientTest {
     assertEquals("Provided bad Call ID", error.getErrorDescription());
 
     assertThrows(
-        OCPPUnsupportedMessage.class, () -> client.handleMessage("[2,\"w\", \"Water\", {}]"));
+        OCPPUnsupportedMessage.class, () -> client.handleMessage("[2,\"w1\", \"Water\", {}]"));
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.NotSupported, error.getErrorCode());
     assertEquals("Unsupported action", error.getErrorDescription());
 
     assertThrows(
-        OCPPBadMessage.class, () -> client.handleMessage("[2,\"w\", \"Heartbeat\", {}, {}]"));
+        OCPPBadMessage.class, () -> client.handleMessage("[2,\"w2\", \"Heartbeat\", {}, {}]"));
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.OccurenceConstraintViolation, error.getErrorCode());
     assertEquals("Request provided wrong number of array elements", error.getErrorDescription());
 
     assertThrows(
-        OCPPBadMessage.class, () -> client.handleMessage("[4,\"w\", 2, \"Heartbeat\", {}, {}]"));
+        OCPPBadMessage.class, () -> client.handleMessage("[4,\"w3\", 2, \"Heartbeat\", {}, {}]"));
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.OccurenceConstraintViolation, error.getErrorCode());
     assertEquals("Error provided wrong number of array elements", error.getErrorDescription());
 
     assertThrows(
-        OCPPBadMessage.class, () -> client.handleMessage("[3,\"w\", \"Heartbeat\", {}, {}]"));
+        OCPPBadMessage.class, () -> client.handleMessage("[3,\"w4\", \"Heartbeat\", {}, {}]"));
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.OccurenceConstraintViolation, error.getErrorCode());
     assertEquals("Response provided wrong number of array elements", error.getErrorDescription());
 
-    assertThrows(OCPPCannotProcessMessage.class, () -> client.handleMessage("[3,\"w\", {}]"));
+    assertThrows(OCPPCannotProcessMessage.class, () -> client.handleMessage("[3,\"w5\", {}]"));
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.ProtocolError, error.getErrorCode());
     assertEquals("Received Response with an unknown ID", error.getErrorDescription());
 
     assertThrows(
-        OCPPCannotProcessMessage.class, () -> client.handleMessage("[4,\"w\", 2, \"w\", {}]"));
+        OCPPCannotProcessMessage.class, () -> client.handleMessage("[4,\"w6\", 2, \"w\", {}]"));
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.ProtocolError, error.getErrorCode());
     assertEquals("Received Error with an unknown ID", error.getErrorDescription());
 
     Heartbeat beat = new Heartbeat();
-    beat.setMessageID("heartbeat");
+    beat.setMessageID("heartbeat1");
     client.addPreviousMessage(beat);
-    client.handleMessage("[4,\"heartbeat\", 29999, \"w\", {}]");
+    client.handleMessage("[4,\"heartbeat1\", 29999, \"w\", {}]");
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.PropertyConstraintViolation, error.getErrorCode());
     assertEquals("Received Unknown Error Code", error.getErrorDescription());
 
+    beat.setMessageID("heartbeat2");
     client.addPreviousMessage(beat);
-    client.handleMessage("[4,\"heartbeat\", -1, \"w\", {}]");
+    client.handleMessage("[4,\"heartbeat2\", -1, \"w\", {}]");
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.PropertyConstraintViolation, error.getErrorCode());
     assertEquals("Received Unknown Error Code", error.getErrorDescription());
 
+    beat.setMessageID("heartbeat3");
     client.addPreviousMessage(beat);
-    client.handleMessage("[4,\"heartbeat\", 2, \"w\", a]");
+    client.handleMessage("[4,\"heartbeat3\", 2, \"w\", a]");
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.PropertyConstraintViolation, error.getErrorCode());
     assertEquals("Error details was not a json object", error.getErrorDescription());
 
+    beat.setMessageID("heartbeat4");
     client.addPreviousMessage(beat);
-    client.handleMessage("[3,\"heartbeat\", 2]");
+    client.handleMessage("[3,\"heartbeat4\", 2]");
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.PropertyConstraintViolation, error.getErrorCode());
     assertEquals("Response details was not a json object", error.getErrorDescription());
 
-    client.handleMessage("[2,\"heartbeat\", \"Heartbeat\", 2]");
+    client.handleMessage("[2,\"heartbeat5\", \"Heartbeat\", 2]");
     error = (OCPPMessageError) client.popMessage();
     assertNotNull(error);
     assertEquals(ErrorCode.PropertyConstraintViolation, error.getErrorCode());

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -91,7 +91,7 @@ public class OCPPWebSocketClientTest {
     doAnswer(invocation -> null).when(client).send(anyString());
 
     Heartbeat beat = new Heartbeat();
-    HeartbeatResponse beat2 = new HeartbeatResponse();
+    HeartbeatResponse beat2 = new HeartbeatResponse(new Heartbeat());
 
     client.pushMessage(beat);
     assert client.size() == 1;
@@ -216,7 +216,7 @@ public class OCPPWebSocketClientTest {
 
   @Test
   public void testOnReceiveMessageNoMatchingMsg() throws OCPPMessageFailure, InterruptedException {
-    HeartbeatResponse response = new HeartbeatResponse();
+    HeartbeatResponse response = new HeartbeatResponse(new Heartbeat());
 
     OCPPMessageError error = new OCPPMessageError(ErrorCode.FormatViolation, "", new JsonObject());
 
@@ -273,7 +273,7 @@ public class OCPPWebSocketClientTest {
 
   @Test
   public void testOnReceiveMessage() throws OCPPMessageFailure, InterruptedException {
-    HeartbeatResponse response = new HeartbeatResponse();
+    HeartbeatResponse response = new HeartbeatResponse(new Heartbeat());
 
     Heartbeat beat = new Heartbeat();
     doAnswer(
@@ -401,7 +401,7 @@ public class OCPPWebSocketClientTest {
               doAnswer(
                       invocation2 -> {
                         this.client.addPreviousMessage(beat);
-                        HeartbeatResponse response = new HeartbeatResponse();
+                        HeartbeatResponse response = new HeartbeatResponse(new Heartbeat());
                         response.setMessageID(beat.getMessageID());
                         client.handleMessage(response.toJsonString());
                         return null;
@@ -488,7 +488,7 @@ public class OCPPWebSocketClientTest {
     doAnswer(invocation -> null).when(client).send(anyString());
 
     Heartbeat beat = new Heartbeat();
-    HeartbeatResponse beatResponse = new HeartbeatResponse();
+    HeartbeatResponse beatResponse = new HeartbeatResponse(new Heartbeat());
     beatResponse.setMessageID(beat.getMessageID());
 
     StartTransaction beat2 = new StartTransaction(2, "", 1, "");
@@ -515,7 +515,7 @@ public class OCPPWebSocketClientTest {
     doAnswer(invocation -> null).when(client).send(anyString());
 
     Heartbeat beat = new Heartbeat();
-    HeartbeatResponse beatResponse = new HeartbeatResponse();
+    HeartbeatResponse beatResponse = new HeartbeatResponse(new Heartbeat());
     beatResponse.setMessageID(beat.getMessageID());
 
     StartTransaction beat2 = new StartTransaction(2, "", 1, "");
@@ -557,7 +557,7 @@ public class OCPPWebSocketClientTest {
     client.goOffline();
 
     Heartbeat beat = new Heartbeat();
-    HeartbeatResponse beatResponse = new HeartbeatResponse();
+    HeartbeatResponse beatResponse = new HeartbeatResponse(new Heartbeat());
     beatResponse.setMessageID(beat.getMessageID());
     client.pushMessage(new Heartbeat());
     client.addPreviousMessage(beat);

--- a/backend/src/test/java/com/sim_backend/websockets/messages/AuthorizeResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/AuthorizeResponseTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 public class AuthorizeResponseTest {
   private static @NotNull AuthorizeResponse getAuthorizeResponse() {
     // Create an Authorize response with an Accepted status
-    AuthorizeResponse response = new AuthorizeResponse("Accepted");
+    AuthorizeResponse response = new AuthorizeResponse(new Authorize(), "Accepted");
 
     // Verify the authorization request is created correctly
     assert response.getIdTagInfo().getStatus().getValue().equals("Accepted");

--- a/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/BootNotificationResponseTest.java
@@ -15,7 +15,8 @@ public class BootNotificationResponseTest {
 
   private static @NotNull BootNotificationResponse getBootNotificationResponse(
       ZonedDateTime dateTime) {
-    BootNotificationResponse response = new BootNotificationResponse("Accepted", dateTime, 5);
+    BootNotificationResponse response =
+        new BootNotificationResponse(new BootNotification(), "Accepted", dateTime, 5);
 
     assert response.getStatus().getValue().equals("Accepted");
     assert response.getStatus() == RegistrationStatus.ACCEPTED;

--- a/backend/src/test/java/com/sim_backend/websockets/messages/ChangeConfigurationResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/ChangeConfigurationResponseTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.Test;
 public class ChangeConfigurationResponseTest {
   private static @NotNull ChangeConfigurationResponse getChangeConfigurationResponse() {
     // Create an ChangeConfigurationResponse with an Accepted status
-    ChangeConfigurationResponse response = new ChangeConfigurationResponse("Accepted");
+    ChangeConfigurationResponse response =
+        new ChangeConfigurationResponse(new ChangeConfiguration("k", "v"), "Accepted");
 
     // Verify the ChangeConfiguration request is created correctly
     assert response.getStatus().getValue().equals("Accepted");

--- a/backend/src/test/java/com/sim_backend/websockets/messages/ClearChargingProfileResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/ClearChargingProfileResponseTest.java
@@ -30,7 +30,8 @@ public class ClearChargingProfileResponseTest {
 
     // Create the ClearChargingProfileResponse object
     ClearChargingProfileResponse profile =
-        new ClearChargingProfileResponse(ClearProfileStatus.ACCEPTED);
+        new ClearChargingProfileResponse(
+            new ClearChargingProfile(1, 1, null, 1), ClearProfileStatus.ACCEPTED);
 
     // Assert expected values
     assertSame(ClearProfileStatus.ACCEPTED, profile.getStatus());
@@ -59,7 +60,9 @@ public class ClearChargingProfileResponseTest {
   @Test
   public void testClearChargingProfileResponseWithViolations() {
     // Create the ClearChargingProfileResponse object
-    ClearChargingProfileResponse profile = new ClearChargingProfileResponse(null); // Violation here
+    ClearChargingProfileResponse profile =
+        new ClearChargingProfileResponse(
+            new ClearChargingProfile(1, 1, null, 1), null); // Violation here
 
     // Assert expected values
     assertSame(null, profile.getStatus());

--- a/backend/src/test/java/com/sim_backend/websockets/messages/GetConfigurationResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/GetConfigurationResponseTest.java
@@ -5,6 +5,7 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.ValidationMessage;
 import com.sim_backend.websockets.GsonUtilities;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ public class GetConfigurationResponseTest {
     // Create an GetConfigurationResponse with valid and invalid key
     GetConfigurationResponse response =
         new GetConfigurationResponse(
+            new GetConfiguration(List.of("MeterValueSampleInterval")),
             Arrays.asList(
                 new GetConfigurationResponse.Configuration("MeterValueSampleInterval", "22", true),
                 new GetConfigurationResponse.Configuration(

--- a/backend/src/test/java/com/sim_backend/websockets/messages/HeartbeatResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/HeartbeatResponseTest.java
@@ -14,7 +14,7 @@ public class HeartbeatResponseTest {
 
   @Test
   public void testHeartbeatResponse() {
-    HeartbeatResponse response = new HeartbeatResponse();
+    HeartbeatResponse response = new HeartbeatResponse(new Heartbeat());
 
     // Ensure message generation works
     assert response.generateMessage().size() == 3;

--- a/backend/src/test/java/com/sim_backend/websockets/messages/HeartbeatTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/HeartbeatTest.java
@@ -30,7 +30,7 @@ public class HeartbeatTest {
   @Test
   public void testHeartbeatConstructor() {
     ZonedDateTime time = ZonedDateTime.of(2004, 10, 10, 10, 2, 10, 10, ZoneId.of("UTC"));
-    HeartbeatResponse heartBeat = new HeartbeatResponse(time);
+    HeartbeatResponse heartBeat = new HeartbeatResponse(new Heartbeat(), time);
     assert heartBeat.getCurrentTime() == time;
   }
 
@@ -53,7 +53,7 @@ public class HeartbeatTest {
 
   @Test
   public void testResponseJSON() {
-    HeartbeatResponse heartBeat = new HeartbeatResponse();
+    HeartbeatResponse heartBeat = new HeartbeatResponse(new Heartbeat());
     JsonSchema jsonSchema = JsonSchemaHelper.getJsonSchema("schemas/HeartbeatResponse.json");
     JsonElement jsonElement = heartBeat.generateMessage().get(2);
     Set<ValidationMessage> errors =
@@ -66,12 +66,14 @@ public class HeartbeatTest {
     assert errors.isEmpty();
 
     heartBeat =
-        new HeartbeatResponse(ZonedDateTime.of(2004, 10, 10, 10, 2, 10, 10, ZoneId.of("UTC")));
+        new HeartbeatResponse(
+            new Heartbeat(), ZonedDateTime.of(2004, 10, 10, 10, 2, 10, 10, ZoneId.of("UTC")));
     String json = GsonUtilities.toString(heartBeat.generateMessage().get(2));
     assert json.contains("\"currentTime\":\"2004-10-10T10:02:10.00000001Z\"");
 
     heartBeat =
-        new HeartbeatResponse(ZonedDateTime.of(2004, 10, 10, 10, 2, 10, 10, ZoneId.of("UTC-7")));
+        new HeartbeatResponse(
+            new Heartbeat(), ZonedDateTime.of(2004, 10, 10, 10, 2, 10, 10, ZoneId.of("UTC-7")));
     json = GsonUtilities.toString(heartBeat.generateMessage().get(2));
     assert json.contains("\"currentTime\":\"2004-10-10T10:02:10.00000001-07:00\"");
   }

--- a/backend/src/test/java/com/sim_backend/websockets/messages/SetChargingProfileResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/SetChargingProfileResponseTest.java
@@ -25,7 +25,8 @@ public class SetChargingProfileResponseTest {
   public void testSetChargingProfileResponse_ValidStatus() {
     // Create a valid SetChargingProfileResponse with a non-blank status
     SetChargingProfileResponse response =
-        new SetChargingProfileResponse(ChargingProfileStatus.ACCEPTED);
+        new SetChargingProfileResponse(
+            new SetChargingProfile(1, null), ChargingProfileStatus.ACCEPTED);
 
     // Validate the response object
     var violations = validator.validate(response);
@@ -37,7 +38,8 @@ public class SetChargingProfileResponseTest {
   @Test
   public void testSetChargingProfileResponse_BlankStatus() {
     // Create a SetChargingProfileResponse with a null or blank status (invalid)
-    SetChargingProfileResponse response = new SetChargingProfileResponse(null);
+    SetChargingProfileResponse response =
+        new SetChargingProfileResponse(new SetChargingProfile(1, null), null);
 
     // Validate the response object
     var violations = validator.validate(response);
@@ -55,7 +57,8 @@ public class SetChargingProfileResponseTest {
   public void testSetChargingProfileResponse_ValidChargingProfileStatus() {
     // Create a valid SetChargingProfileResponse with a specific status
     SetChargingProfileResponse response =
-        new SetChargingProfileResponse(ChargingProfileStatus.REJECTED);
+        new SetChargingProfileResponse(
+            new SetChargingProfile(1, null), ChargingProfileStatus.REJECTED);
 
     // Assert that the status is correctly set
     assertEquals(

--- a/backend/src/test/java/com/sim_backend/websockets/messages/StartTransactionResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/StartTransactionResponseTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.Test;
 public class StartTransactionResponseTest {
   private static @NotNull StartTransactionResponse getStartTransactionResponse() {
     // Create an StartTransaction response
-    StartTransactionResponse response = new StartTransactionResponse(1, "Accepted");
+    StartTransactionResponse response =
+        new StartTransactionResponse(new StartTransaction(1, "", 1, ""), 1, "Accepted");
 
     // Verify the StartTransaction Request is created correctly
     assert response.getTransactionId() == 1;

--- a/backend/src/test/java/com/sim_backend/websockets/messages/StopTransactionResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/messages/StopTransactionResponseTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.Test;
 public class StopTransactionResponseTest {
   private static @NotNull StopTransactionResponse getStopTransactionResponse() {
     // Create an StopTransaction response
-    StopTransactionResponse response = new StopTransactionResponse("Accepted");
+    StopTransactionResponse response =
+        new StopTransactionResponse(new StopTransaction("", 1, 1, ""), "Accepted");
 
     // Verify the StopTransaction Request is created correctly
     assert response.getIdTagInfo().getStatus() == AuthorizationStatus.ACCEPTED;

--- a/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/observers/BootNotificationObserverTest.java
@@ -68,7 +68,8 @@ class BootNotificationObserverTest {
     // Arrange
     BootNotificationResponse response =
         Mockito.spy(
-            new BootNotificationResponse(RegistrationStatus.ACCEPTED, ZonedDateTime.now(), 20));
+            new BootNotificationResponse(
+                new BootNotification(), RegistrationStatus.ACCEPTED, ZonedDateTime.now(), 20));
 
     MessageScheduler messageScheduler = mock(MessageScheduler.class);
     OCPPTime time = mock(OCPPTime.class);
@@ -93,7 +94,8 @@ class BootNotificationObserverTest {
     // Arrange
     BootNotificationResponse response =
         Mockito.spy(
-            new BootNotificationResponse(RegistrationStatus.PENDING, ZonedDateTime.now(), 20));
+            new BootNotificationResponse(
+                new BootNotification(), RegistrationStatus.PENDING, ZonedDateTime.now(), 20));
 
     MessageScheduler messageScheduler = mock(MessageScheduler.class);
     when(webSocketClient.getScheduler()).thenReturn(messageScheduler);
@@ -114,7 +116,8 @@ class BootNotificationObserverTest {
     // Arrange
     BootNotificationResponse response =
         Mockito.spy(
-            new BootNotificationResponse(RegistrationStatus.REJECTED, ZonedDateTime.now(), 240));
+            new BootNotificationResponse(
+                new BootNotification(), RegistrationStatus.REJECTED, ZonedDateTime.now(), 240));
 
     MessageScheduler messageScheduler = mock(MessageScheduler.class);
     when(webSocketClient.getScheduler()).thenReturn(messageScheduler);

--- a/backend/src/test/java/com/sim_backend/websockets/types/OCPPMessageResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/types/OCPPMessageResponseTest.java
@@ -1,0 +1,16 @@
+package com.sim_backend.websockets.types;
+
+import com.sim_backend.websockets.messages.Authorize;
+import com.sim_backend.websockets.messages.AuthorizeResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OCPPMessageResponseTest {
+    @Test
+    public void testResponseID() {
+        Authorize authorize = new Authorize();
+        AuthorizeResponse response = new AuthorizeResponse(authorize, "Accepted");
+        assertEquals(response.getMessageID(), authorize.getMessageID());
+    }
+}

--- a/backend/src/test/java/com/sim_backend/websockets/types/OCPPMessageResponseTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/types/OCPPMessageResponseTest.java
@@ -1,16 +1,16 @@
 package com.sim_backend.websockets.types;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.sim_backend.websockets.messages.Authorize;
 import com.sim_backend.websockets.messages.AuthorizeResponse;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class OCPPMessageResponseTest {
-    @Test
-    public void testResponseID() {
-        Authorize authorize = new Authorize();
-        AuthorizeResponse response = new AuthorizeResponse(authorize, "Accepted");
-        assertEquals(response.getMessageID(), authorize.getMessageID());
-    }
+  @Test
+  public void testResponseID() {
+    Authorize authorize = new Authorize();
+    AuthorizeResponse response = new AuthorizeResponse(authorize, "Accepted");
+    assertEquals(response.getMessageID(), authorize.getMessageID());
+  }
 }


### PR DESCRIPTION
Added a requirement to need the request to create a response object, also prevented the ability to received the same id twice.