### PR TITLE
Cscap 96/append id to url

### DIFF
--- a/backend/src/main/java/com/sim_backend/charger/Charger.java
+++ b/backend/src/main/java/com/sim_backend/charger/Charger.java
@@ -57,7 +57,7 @@ public class Charger {
   /** Constructs a new Charger instance */
   public Charger() {
     // TODO: Get central system URI from frontend or command line
-    this.config = new ConfigurationRegistry("temptag", "ws://host.docker.internal:9000");
+    this.config = new ConfigurationRegistry("test", "ws://host.docker.internal:9000");
   }
 
   /**
@@ -87,7 +87,8 @@ public class Charger {
       elec = new ElectricalTransition(stateMachine);
       wsClient =
           new OCPPWebSocketClient(
-              URI.create(config.getCentralSystemUrl()), statusNotificationObserver);
+              URI.create(config.getCentralSystemUrl() + "/" + config.getIdTag()),
+              statusNotificationObserver);
       transactionHandler = new TransactionHandler(this);
 
       // Create Observers

--- a/dummy_server/WebSocketServer.js
+++ b/dummy_server/WebSocketServer.js
@@ -17,6 +17,14 @@ const startWebSocketServer = (port = 9000, receivedMessages) => {
 
   const wss = new WebSocketServer({
     port: port,
+    // Only allow connections whose request URL is '/test'
+    verifyClient: (info, done) => {
+      if (info.req.url === "/test") {
+        done(true);
+      } else {
+        done(false, 403, "Forbidden");
+      }
+    },
     handleProtocols: (protocols, request) => {
       if (protocols.has("ocpp1.6")) {
         return "ocpp1.6";
@@ -71,7 +79,6 @@ const startWebSocketServer = (port = 9000, receivedMessages) => {
       }
     });
     
-
     ws.on("close", () => {
       console.log("WebSocket connection closed");
     });


### PR DESCRIPTION
This is an OCPP-J 1.6 requirement:

> 3.1.1. The connection URL
> 
> ....
>
> To derive its connection URL, the Charge Point modifies the OCPP-J endpoint URL by appending to the path first a '/' (U+002F SOLIDUS) and then a string uniquely identifying the Charge Point. This uniquely identifying string has to be percent-encoded as necessary as described in [RFC3986].
> 
> Example 1: for a charge point with identity “CP001” connecting to a Central System with OCPP-J endpoint URL "ws://centralsystem.example.com/ocpp" this would give the following connection URL:
ws://centralsystem.example.com/ocpp/CP001
