### PR TITLE
Fixed issue where offline jobs would stack

### DIFF
--- a/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
+++ b/backend/src/main/java/com/sim_backend/websockets/MessageScheduler.java
@@ -93,7 +93,8 @@ public class MessageScheduler {
             getTime().getSynchronizedTime().plus(initialDelay, timeUnit.toChronoUnit()),
             delay,
             timeUnit.toChronoUnit(),
-            task);
+            task,
+            client);
     tasks.add(repeatingTask);
     return repeatingTask;
   }

--- a/backend/src/main/java/com/sim_backend/websockets/types/OCPPRepeatingTimedTask.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/OCPPRepeatingTimedTask.java
@@ -22,7 +22,8 @@ public class OCPPRepeatingTimedTask extends OCPPTimedTask implements RepeatingTa
 
   @Override
   public TimedTask repeatTask() {
-    ZonedDateTime nextExecutionTime = time.plus(this.repeatDelay, this.unit);
+    ZonedDateTime now = client.getScheduler().getTime().getSynchronizedTime();
+    ZonedDateTime nextExecutionTime = now.plus(this.repeatDelay, this.unit);
     return new OCPPRepeatingTimedTask(
         nextExecutionTime, this.repeatDelay, this.unit, this.message, this.client);
   }

--- a/backend/src/main/java/com/sim_backend/websockets/types/RepeatingTimedTask.java
+++ b/backend/src/main/java/com/sim_backend/websockets/types/RepeatingTimedTask.java
@@ -1,5 +1,6 @@
 package com.sim_backend.websockets.types;
 
+import com.sim_backend.websockets.OCPPWebSocketClient;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -8,17 +9,24 @@ public class RepeatingTimedTask extends TimedTask implements RepeatingTask {
   public long repeatDelay;
   public ChronoUnit unit;
   private final AtomicBoolean cancelled;
+  private OCPPWebSocketClient client;
 
   public boolean isCancelled() {
     return cancelled.get();
   }
 
   // Public constructor creates a new cancellation flag
-  public RepeatingTimedTask(ZonedDateTime time, long repeatTime, ChronoUnit unit, Runnable task) {
+  public RepeatingTimedTask(
+      ZonedDateTime time,
+      long repeatTime,
+      ChronoUnit unit,
+      Runnable task,
+      OCPPWebSocketClient client) {
     super(time, task);
     this.unit = unit;
     this.repeatDelay = repeatTime;
     this.cancelled = new AtomicBoolean(false);
+    this.client = client;
   }
 
   // Private constructor to propagate the cancellation flag
@@ -27,11 +35,13 @@ public class RepeatingTimedTask extends TimedTask implements RepeatingTask {
       long repeatTime,
       ChronoUnit unit,
       Runnable task,
-      AtomicBoolean cancelled) {
+      AtomicBoolean cancelled,
+      OCPPWebSocketClient client) {
     super(time, task);
     this.unit = unit;
     this.repeatDelay = repeatTime;
     this.cancelled = cancelled;
+    this.client = client;
   }
 
   @Override
@@ -39,9 +49,10 @@ public class RepeatingTimedTask extends TimedTask implements RepeatingTask {
     if (cancelled.get()) {
       return null; // Don't create a new task if cancelled
     }
-    ZonedDateTime nextExecutionTime = time.plus(this.repeatDelay, this.unit);
+    ZonedDateTime now = client.getScheduler().getTime().getSynchronizedTime();
+    ZonedDateTime nextExecutionTime = now.plus(this.repeatDelay, this.unit);
     return new RepeatingTimedTask(
-        nextExecutionTime, this.repeatDelay, this.unit, this.task, this.cancelled);
+        nextExecutionTime, this.repeatDelay, this.unit, this.task, this.cancelled, this.client);
   }
 
   // Method to cancel the repeating task

--- a/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
@@ -200,17 +200,25 @@ public class MessageSchedulerTest {
 
   @Test
   void testTickExecutesRepeatingTask() {
-    ZonedDateTime initialTime = ZonedDateTime.now().plusSeconds(5);
+    // Use a fixed time to avoid drift
+    ZonedDateTime fixedTime = ZonedDateTime.parse("2025-03-12T12:00:00Z");
+    when(time.getSynchronizedTime()).thenReturn(fixedTime);
+    // Ensure that when client.getScheduler() is called, it returns our test scheduler
+    when(client.getScheduler()).thenReturn(scheduler);
+
     long repeatDelay = 10L; // Task repeats every 10 seconds
 
     // Create a repeating task
     OCPPRepeatingTimedTask repeatingTask =
         new OCPPRepeatingTimedTask(
-            initialTime, repeatDelay, ChronoUnit.SECONDS, new Heartbeat(), client);
+            fixedTime.minusSeconds(1),
+            repeatDelay,
+            ChronoUnit.SECONDS,
+            new Heartbeat(),
+            client);
 
     // Add the task manually
     scheduler.tasks.add(repeatingTask);
-    when(time.getSynchronizedTime()).thenReturn(ZonedDateTime.now().plusSeconds(15));
 
     // Perform a tick
     scheduler.tick();
@@ -218,10 +226,10 @@ public class MessageSchedulerTest {
     // Verify that the task was executed
     verify(client, times(1)).pushMessage(any(OCPPMessage.class));
 
-    // Verify that the task is rescheduled with the repeat delay
-    assertTrue(
-        scheduler.tasks.stream()
-            .anyMatch(t -> t.time.isEqual(initialTime.plusSeconds(repeatDelay))));
+    // Verify that the task is rescheduled with the repeat delay from the fixed time
+    ZonedDateTime expectedNextExecutionTime = fixedTime.plusSeconds(repeatDelay);
+    ZonedDateTime actualNextExecutionTime = scheduler.tasks.get(0).time;
+    assertEquals(expectedNextExecutionTime, actualNextExecutionTime);
   }
 
   @Test
@@ -321,7 +329,7 @@ public class MessageSchedulerTest {
     AtomicBoolean executed = new AtomicBoolean(false);
     Runnable taskRunnable = () -> executed.set(true);
     RepeatingTimedTask repeatingTask =
-        new RepeatingTimedTask(scheduledTime, 10, ChronoUnit.SECONDS, taskRunnable);
+        new RepeatingTimedTask(scheduledTime, 10, ChronoUnit.SECONDS, taskRunnable, client);
 
     // Cancel the task so it should not run
     repeatingTask.cancel();
@@ -341,7 +349,7 @@ public class MessageSchedulerTest {
     AtomicBoolean executed = new AtomicBoolean(false);
     Runnable taskRunnable = () -> executed.set(true);
     RepeatingTimedTask repeatingTask =
-        new RepeatingTimedTask(scheduledTime, 10, ChronoUnit.SECONDS, taskRunnable);
+        new RepeatingTimedTask(scheduledTime, 10, ChronoUnit.SECONDS, taskRunnable, client);
 
     // Cancel the task so that repeatTask() returns null
     repeatingTask.cancel();

--- a/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/MessageSchedulerTest.java
@@ -211,11 +211,7 @@ public class MessageSchedulerTest {
     // Create a repeating task
     OCPPRepeatingTimedTask repeatingTask =
         new OCPPRepeatingTimedTask(
-            fixedTime.minusSeconds(1),
-            repeatDelay,
-            ChronoUnit.SECONDS,
-            new Heartbeat(),
-            client);
+            fixedTime.minusSeconds(1), repeatDelay, ChronoUnit.SECONDS, new Heartbeat(), client);
 
     // Add the task manually
     scheduler.tasks.add(repeatingTask);


### PR DESCRIPTION
This PR changes the scheduling of repeated tasks. Instead of adding their repeat delay to their original scheduled time, they now add the repeat delay to the current time.

When our simulator was offline, going back online would result in a burst of heartbeat messages. The original scheduled time + the delay would be in the past for several iterations, making the job reschedule itself several times.