### PR TITLE
Prevent config modal stacking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ docker_debug:
 integration_test:
 	docker-compose --env-file .env.internal --profile integration-test up --build
 
+unit_test:
+	docker-compose --profile unit_test up --build
+
 dummy_server:
 	NORMAL_MODE=enabled docker compose --profile core --profile dummy-server up --build
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import './styles/styles.css';
 
 function App() {
   const [status, setStatus] = useState('loading');
+  const [openModalChargerID, setOpenModalChargerID] = useState(null); // Track which charger modal is open (null if none)
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_BACKEND_URL}/api/test`)
@@ -41,7 +42,12 @@ function App() {
       <div className="charger-frames-container">
         {[1, 2, 3].map((id) => (
           <div key={id} className="charger-container">
-            <ChargerFrame chargerID={id} />
+            {/* Pass down the config modal state and its setter */}
+            <ChargerFrame
+              chargerID={id}
+              openModalChargerID={openModalChargerID}
+              setOpenModalChargerID={setOpenModalChargerID}
+            />
             <ShowLogMessages chargerID={id} />
           </div>
         ))}

--- a/frontend/src/components/ChargerFrame.js
+++ b/frontend/src/components/ChargerFrame.js
@@ -9,7 +9,11 @@ import ErrorMenu from './ErrorMenu';
 import ConfigGear from './ConfigIdTagUrl';
 import PropTypes from 'prop-types';
 
-function ChargerFrame({ chargerID }) {
+function ChargerFrame({
+  chargerID,
+  openModalChargerID,
+  setOpenModalChargerID,
+}) {
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -61,7 +65,12 @@ function ChargerFrame({ chargerID }) {
       <RebootButton chargerID={chargerID} />
       <Button chargerID={chargerID} isOnline={isOnline} isActive={isActive} />
       <div className="config-button-container">
-        <ConfigGear chargerID={chargerID} />
+        {/* Pass the config modal state down to the gear component */}
+        <ConfigGear
+          chargerID={chargerID}
+          openModalChargerID={openModalChargerID}
+          setOpenModalChargerID={setOpenModalChargerID}
+        />
       </div>
       <ErrorMenu chargerID={chargerID} />
     </div>
@@ -70,6 +79,8 @@ function ChargerFrame({ chargerID }) {
 
 ChargerFrame.propTypes = {
   chargerID: PropTypes.number.isRequired,
+  openModalChargerID: PropTypes.number,
+  setOpenModalChargerID: PropTypes.func.isRequired,
 };
 
 export default ChargerFrame;

--- a/frontend/src/components/ConfigIdTagUrl.js
+++ b/frontend/src/components/ConfigIdTagUrl.js
@@ -3,8 +3,7 @@ import { FaCog, FaTimes } from 'react-icons/fa';
 import PropTypes from 'prop-types';
 import '../styles/styles.css';
 
-function ConfigGear({ chargerID }) {
-  const [showConfigModal, setShowConfigModal] = useState(false);
+function ConfigGear({ chargerID, openModalChargerID, setOpenModalChargerID }) {
   const [idTag, setIdTag] = useState('');
   const [centralSystemUrl, setCentralSystemUrl] = useState('');
   const [message, setMessage] = useState('');
@@ -23,7 +22,7 @@ function ConfigGear({ chargerID }) {
         }
       );
       if (!response.ok) {
-        setMessage('Failed to fetch configration values.');
+        setMessage('Failed to fetch configuration values.');
         setMessageType('error');
         throw new Error('Failed to fetch configuration');
       }
@@ -64,8 +63,10 @@ function ConfigGear({ chargerID }) {
 
   // Handle modal opening and fetching config
   const handleClick = async () => {
+    // Allow opening only if no config modal is open or it’s already open on this charger
+    if (openModalChargerID && openModalChargerID !== chargerID) return;
     await fetchConfig();
-    setShowConfigModal(true);
+    setOpenModalChargerID(chargerID);
   };
 
   // Handle update action
@@ -77,7 +78,8 @@ function ConfigGear({ chargerID }) {
     }
     try {
       await updateConfig();
-      setShowConfigModal(false); // Close modal immediately after success
+      // Close modal by clearing the shared state
+      setOpenModalChargerID(null);
       setMessage('');
     } catch (error) {
       console.error('Error updating configuration:', error);
@@ -86,12 +88,19 @@ function ConfigGear({ chargerID }) {
 
   return (
     <div>
-      <div onClick={handleClick} className="config-button">
+      <div
+        onClick={
+          openModalChargerID === null || openModalChargerID === chargerID
+            ? handleClick
+            : null
+        }
+        className={`config-button ${openModalChargerID === chargerID ? 'highlight' : ''} ${openModalChargerID && openModalChargerID !== chargerID ? 'disabled' : ''}`}
+      >
         <FaCog /> {/* Gear icon */}
       </div>
 
       {/* Modal for configuration */}
-      {showConfigModal && (
+      {openModalChargerID === chargerID && (
         <div className="config-modal-overlay">
           <div className="config-modal-content">
             <h2 className="config-heading">Update Configuration</h2>
@@ -134,7 +143,7 @@ function ConfigGear({ chargerID }) {
               Update
             </button>
             <button
-              onClick={() => setShowConfigModal(false)}
+              onClick={() => setOpenModalChargerID(null)}
               className="config-button-exit"
             >
               Exit
@@ -148,6 +157,8 @@ function ConfigGear({ chargerID }) {
 
 ConfigGear.propTypes = {
   chargerID: PropTypes.number.isRequired,
+  openModalChargerID: PropTypes.number,
+  setOpenModalChargerID: PropTypes.func.isRequired,
 };
 
 export default ConfigGear;

--- a/frontend/src/styles/styles.css
+++ b/frontend/src/styles/styles.css
@@ -502,6 +502,23 @@ button:active {
   color: var(--config-grey);
 }
 
+.config-button.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+  cursor: default;
+}
+
+.config-button.disabled:hover {
+  background-color: transparent;
+}
+
+/* Mark the currently active gear icon */
+.config-button.highlight {
+  background-color: var(--light-grey);
+  border: 2px solid var(--config-grey);
+  border-radius: 4px;
+}
+
 /* Modal overlay (background) */
 .config-modal-overlay {
   position: fixed;


### PR DESCRIPTION
Prior to this PR, clicking the gear icon on multiple chargers would "stack" the modals up. So you could open multiple at the same time.

This PR also highlights the currently opened gear icon.
<img width="1436" alt="Screenshot 2025-03-14 at 4 24 40 PM" src="https://github.com/user-attachments/assets/f3a3f8cd-e1a6-4a10-ab96-ca3ec857b9ef" />
