### PR TITLE
Prevent faulting or going offline when booting

### DIFF
--- a/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
@@ -11,6 +11,7 @@ package com.sim_backend.rest.controllers;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.sim_backend.charger.Charger;
+import com.sim_backend.state.ChargerState;
 import com.sim_backend.state.ChargerStateMachine;
 import com.sim_backend.websockets.enums.ChargePointErrorCode;
 import com.sim_backend.websockets.enums.ChargePointStatus;
@@ -123,8 +124,7 @@ public class MessageController extends ControllerBase {
   public void state(Context ctx) {
     Charger charger = getChargerID(ctx);
     if (charger == null) return;
-    if (!checkWsClient(charger, ctx)) return;
-    if (!checkStateMachine(charger, ctx)) return;
+
     ChargerStateMachine stateMachine = charger.getStateMachine();
     if (stateMachine == null) {
       ctx.result("PoweredOff");
@@ -163,6 +163,11 @@ public class MessageController extends ControllerBase {
     Charger charger = getChargerID(ctx);
     if (charger == null) return;
     if (!checkWsClient(charger, ctx)) return;
+    if (!checkStateMachine(charger, ctx)) return;
+
+    if (charger.getStateMachine().getCurrentState() == ChargerState.BootingUp) {
+      ctx.status(503).result("Charger is booting");
+    }
 
     charger.getWsClient().goOffline();
     ctx.result("OK");

--- a/backend/src/main/java/com/sim_backend/state/ChargerStateMachine.java
+++ b/backend/src/main/java/com/sim_backend/state/ChargerStateMachine.java
@@ -16,7 +16,7 @@ public class ChargerStateMachine {
           ChargerState.PoweredOff,
           Set.of(ChargerState.BootingUp),
           ChargerState.BootingUp,
-          Set.of(ChargerState.Available, ChargerState.Faulted, ChargerState.Unavailable),
+          Set.of(ChargerState.Available, ChargerState.Unavailable),
           ChargerState.Available,
           Set.of(ChargerState.Preparing, ChargerState.Faulted, ChargerState.Unavailable),
           ChargerState.Preparing,

--- a/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
+++ b/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
@@ -13,6 +13,8 @@ import com.sim_backend.state.ChargerState;
 import com.sim_backend.state.ChargerStateMachine;
 import com.sim_backend.transactions.TransactionHandler;
 import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.enums.ChargePointErrorCode;
+import com.sim_backend.websockets.enums.ChargePointStatus;
 import com.sim_backend.websockets.messages.Authorize;
 import com.sim_backend.websockets.messages.BootNotification;
 import com.sim_backend.websockets.messages.Heartbeat;
@@ -20,8 +22,10 @@ import com.sim_backend.websockets.messages.StatusNotification;
 import com.sim_backend.websockets.observers.StatusNotificationObserver;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -169,6 +173,23 @@ class MessageControllerTest {
   }
 
   @Test
+  void testOfflineBooting() {
+    // Arrange
+    when(mockStateMachine.getCurrentState()).thenReturn(ChargerState.BootingUp);
+
+    // Act
+    messageController.offline(mockContext);
+
+    // Assert
+    InOrder inOrder = inOrder(mockContext, mockWsClient);
+    inOrder.verify(mockContext).status(503);
+    inOrder.verify(mockContext).result("Charger is booting");
+    
+    inOrder.verify(mockWsClient).goOffline();
+    inOrder.verify(mockContext).result("OK");
+  }
+
+  @Test
   void testStatus() {
     // Arrange
     when(mockStateMachine.getCurrentState()).thenReturn(ChargerState.Available);
@@ -187,6 +208,61 @@ class MessageControllerTest {
     messageController.status(mockContext);
 
     // Assert
+    verify(mockContext).result("OK");
+  }
+
+  @Test
+  void testStatus_invalidConnector() {
+    // Arrange
+    // Use an invalid connectorId to trigger an exception
+    String requestBody = "{" + "\"connectorId\": \"2\"," + "\"errorCode\": \"NoError\"" + "}";
+    when(mockContext.body()).thenReturn(requestBody);
+
+    // Act
+    messageController.status(mockContext);
+
+    // Assert
+    verify(mockContext).status(400);
+    verify(mockContext).result("Invalid values for connectorId, errorCode");
+  }
+
+  @Test
+  void testStatusWithFault() {
+    // Arrange
+    String requestBody =
+        "{"
+            + "\"connectorId\": \"0\","
+            + "\"errorCode\": \"HighTemperature\","
+            + "\"info\": \"Error occurred\","
+            + "\"vendorId\": \"Vendor\","
+            + "\"vendorErrorCode\": \"VError\""
+            + "}";
+    when(mockContext.body()).thenReturn(requestBody);
+    when(mockStateMachine.getCurrentState()).thenReturn(ChargerState.Available);
+
+    // When fault() is called, simulate that the charger state becomes Faulted
+    doAnswer(
+            invocation -> {
+              when(mockStateMachine.getCurrentState()).thenReturn(ChargerState.Faulted);
+              return null;
+            })
+        .when(mockCharger)
+        .fault(any());
+
+    // Act
+    messageController.status(mockContext);
+
+    // Assert
+    verify(mockCharger).fault(ChargePointErrorCode.HighTemperature);
+    verify(mockStatusNotificationObserver)
+        .sendStatusNotification(
+            eq(0),
+            eq(ChargePointErrorCode.HighTemperature),
+            eq("Error occurred"),
+            eq(ChargePointStatus.Faulted),
+            eq(null),
+            eq("Vendor"),
+            eq("VError"));
     verify(mockContext).result("OK");
   }
 
@@ -264,6 +340,109 @@ class MessageControllerTest {
   }
 
   @Test
+  void testGetSentMessages() {
+    // Arrange
+    List<String> sentMessages = List.of("1", "2", "3");
+    when(mockWsClient.getSentMessages()).thenReturn(sentMessages);
+
+    // Act
+    messageController.getSentMessages(mockContext);
+
+    // Assert
+    verify(mockContext).json(sentMessages);
+  }
+
+  @Test
+  void testGetReceivedMessages() {
+    // Arrange
+    List<String> receivedMessages = List.of("4", "5", "6");
+    when(mockWsClient.getReceivedMessages()).thenReturn(receivedMessages);
+
+    // Act
+    messageController.getReceivedMessages(mockContext);
+
+    // Assert
+    verify(mockContext).json(receivedMessages);
+  }
+
+  @Test
+  void testGetIdTagCSurl() {
+    // Arrange
+    when(mockConfig.getIdTag()).thenReturn("testTag");
+    when(mockConfig.getCentralSystemUrl()).thenReturn("ws://example.com");
+
+    // Act
+    messageController.getIdTagCSurl(mockContext);
+
+    // Assert
+    String expectedJson = "{\"idTag\":\"testTag\", \"centralSystemUrl\":\"ws://example.com\"}";
+    verify(mockContext).json(expectedJson);
+  }
+
+  @Test
+  void testUpdateIdTagCSurl_valid() {
+    // Arrange
+    String requestBody = "{\"idTag\": \"newTag\", \"centralSystemUrl\": \"ws://newurl.com\"}";
+    when(mockContext.body()).thenReturn(requestBody);
+
+    // Act
+    messageController.updateIdTagCSurl(mockContext);
+
+    // Assert
+    verify(mockConfig).setIdTag("newTag");
+    verify(mockConfig).setCentralSystemUrl("ws://newurl.com");
+    String expectedMessage =
+        "Config updated successfully. idTag: newTag, centralSystemUrl: ws://newurl.com";
+    verify(mockContext).status(200);
+    verify(mockContext).result(expectedMessage);
+  }
+
+  @Test
+  void testUpdateIdTagCSurl_missingIdTag() {
+    // Arrange
+    String requestBody = "{\"centralSystemUrl\": \"ws://newurl.com\"}";
+    when(mockContext.body()).thenReturn(requestBody);
+
+    // Act
+    messageController.updateIdTagCSurl(mockContext);
+
+    // Assert
+    verify(mockContext).status(400);
+    verify(mockContext).result("Error: Missing idTag or centralSystemUrl.");
+  }
+
+  @Test
+  void testUpdateIdTagCSurl_missingCentralSystemUrl() {
+    // Arrange
+    String requestBody = "{\"idTag\": \"newTag\"}";
+    when(mockContext.body()).thenReturn(requestBody);
+
+    // Act
+    messageController.updateIdTagCSurl(mockContext);
+
+    // Assert
+    verify(mockContext).status(400);
+    verify(mockContext).result("Error: Missing idTag or centralSystemUrl.");
+  }
+
+  @Test
+  void testUpdateIdTagCSurl_idTagTooLong() {
+    // Arrange
+    String longIdTag = "thisisaverylongidtagexceedinglimit";
+    String requestBody =
+        String.format(
+            "{\"idTag\": \"%s\", \"centralSystemUrl\": \"ws://newurl.com\"}", longIdTag);
+    when(mockContext.body()).thenReturn(requestBody);
+
+    // Act
+    messageController.updateIdTagCSurl(mockContext);
+
+    // Assert
+    verify(mockContext).status(400);
+    verify(mockContext).result("Error: idTag cannot exceed 20 characters.");
+  }
+
+  @Test
   void testRegisterRoutes() {
     // Act
     messageController.registerRoutes(mockApp);
@@ -283,5 +462,7 @@ class MessageControllerTest {
     verify(mockApp).get(eq("/api/{chargerId}/electrical/meter-value"), any());
     verify(mockApp).get(eq("/api/{chargerId}/electrical/max-current"), any());
     verify(mockApp).get(eq("/api/{chargerId}/electrical/current-import"), any());
+    verify(mockApp).get(eq("/api/{chargerId}/get-idtag-csurl"), any());
+    verify(mockApp).post(eq("/api/{chargerId}/update-idtag-csurl"), any());
   }
 }

--- a/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
+++ b/backend/src/test/java/com/sim_backend/rest/MessageControllerTest.java
@@ -184,7 +184,7 @@ class MessageControllerTest {
     InOrder inOrder = inOrder(mockContext, mockWsClient);
     inOrder.verify(mockContext).status(503);
     inOrder.verify(mockContext).result("Charger is booting");
-    
+
     inOrder.verify(mockWsClient).goOffline();
     inOrder.verify(mockContext).result("OK");
   }
@@ -430,8 +430,7 @@ class MessageControllerTest {
     // Arrange
     String longIdTag = "thisisaverylongidtagexceedinglimit";
     String requestBody =
-        String.format(
-            "{\"idTag\": \"%s\", \"centralSystemUrl\": \"ws://newurl.com\"}", longIdTag);
+        String.format("{\"idTag\": \"%s\", \"centralSystemUrl\": \"ws://newurl.com\"}", longIdTag);
     when(mockContext.body()).thenReturn(requestBody);
 
     // Act

--- a/frontend/src/components/Button.js
+++ b/frontend/src/components/Button.js
@@ -50,9 +50,11 @@ function Button({ chargerID, isOnline, isActive }) {
       )}
 
       {/* Bring Online/Take Offline button */}
-      <button onClick={handleOnlineOffline} className="dropdown-button">
-        {isOnline ? 'Take Offline' : 'Bring Online'}
-      </button>
+      {isActive && (
+        <button onClick={handleOnlineOffline} className="dropdown-button">
+          {isOnline ? 'Take Offline' : 'Bring Online'}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ChargerFrame.js
+++ b/frontend/src/components/ChargerFrame.js
@@ -63,7 +63,7 @@ function ChargerFrame({ chargerID }) {
       <div className="config-button-container">
         <ConfigGear chargerID={chargerID} />
       </div>
-      <ErrorMenu chargerID={chargerID} />
+      <ErrorMenu chargerID={chargerID} isActive={isActive} />
     </div>
   );
 }

--- a/frontend/src/components/ErrorMenu.js
+++ b/frontend/src/components/ErrorMenu.js
@@ -21,7 +21,7 @@ const errorCodes = [
   'WeakSignal',
 ];
 
-const ErrorMenu = ({ chargerID }) => {
+const ErrorMenu = ({ chargerID, isActive }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
   const [feedbacktype, setFeedbackType] = useState(false);
@@ -111,9 +111,11 @@ const ErrorMenu = ({ chargerID }) => {
 
   return (
     <div className="error-menu-container">
-      <button className="dropdown-toggle" onClick={openMenu}>
-        Simulate exceptions
-      </button>
+      {isActive && (
+        <button className="dropdown-toggle" onClick={openMenu}>
+          Simulate exceptions
+        </button>
+      )}
       {isOpen && (
         <div className="modal-overlay" onClick={closeMenu}>
           <div className="modal-content" onClick={stopPropagation}>
@@ -212,6 +214,7 @@ const ErrorMenu = ({ chargerID }) => {
 
 ErrorMenu.propTypes = {
   chargerID: PropTypes.number.isRequired, // 'chargerID' should be a number
+  isActive: PropTypes.bool.isRequired, // 'isActive' should be a boolean
 };
 
 export default ErrorMenu;


### PR DESCRIPTION
- There was a bug where you could send a status notification when booting up to fault the charger. Then clear the fault to skip the boot process and go into an available state.
- Also prevent going offline when booting up.
- Also add a few more test cases for our MessageController.
- Additionally, the "Go offline" and "Simulate exceptions" buttons are now hidden when booting up.

The reasoning behind these changes is that since we are not in an OCPP state yet, the handling for being offline or faulting is undefined. I think this was the easiest solution too.


<img width="1440" alt="Screenshot 2025-03-14 at 6 03 37 PM" src="https://github.com/user-attachments/assets/fe48fb01-ff24-4879-821b-3f68aa90910b" />
