### PR TITLE
Use pending status from BootNotificationResponse

### DIFF
--- a/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/BootNotificationObserver.java
@@ -71,9 +71,13 @@ public class BootNotificationObserver implements OnOCPPMessageListener, StateObs
         scheduler.getTime().setHeartbeatInterval(interval, TimeUnit.SECONDS);
         stateMachine.transition(ChargerState.Available);
         scheduler.synchronizeTime(response.getCurrentTime());
+        webSocketClient.deleteOnReceiveMessage(BootNotificationResponse.class, this);
         break;
 
-      case PENDING, REJECTED:
+      case PENDING:
+        // Do nothing
+        break;
+      case REJECTED:
         // Central system is pending or rejected the request, set minimum wait time before next
         // BootNotification request
         if (interval < 0) {

--- a/backend/src/main/java/com/sim_backend/websockets/observers/TriggerMessageObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/TriggerMessageObserver.java
@@ -123,7 +123,7 @@ public class TriggerMessageObserver implements OnOCPPMessageListener {
       case Available:
         return ChargePointStatus.Available;
       case BootingUp:
-        return ChargePointStatus.Preparing;
+        return ChargePointStatus.Unavailable;
       case Preparing:
         return ChargePointStatus.Preparing;
       case Charging:
@@ -131,7 +131,7 @@ public class TriggerMessageObserver implements OnOCPPMessageListener {
       case PoweredOff:
         return ChargePointStatus.Unavailable;
       default:
-        return ChargePointStatus.Available;
+        return ChargePointStatus.Unavailable;
     }
   }
 }


### PR DESCRIPTION
From `4.2` of the OCPP 1.6 spec:
> The Central System MAY also return a Pending registration status to indicate that it wants to retrieve or set certain information on the Charge Point before the Central System will accept the Charge Point. If the Central System returns the Pending status, the communication channel SHOULD NOT be closed by either the Charge Point or the Central System. The Central System MAY send request messages to retrieve information from the Charge Point or change its configuration. The Charge Point SHOULD respond to these messages. The Charge Point SHALL NOT send request messages to the Central System unless it has been instructed by the Central System to do so with a TriggerMessage.req request.
While in pending state, the following Central System initiated messages are not allowed: RemoteStartTransaction.req and RemoteStopTransaction.req

Since we now have `TriggerMessage` implemented, we can use the pending stating. I believe the charger initiated operations are locked down enough where our simulator can safely stay in a booted state for a while