### PR TITLE
Record Tx messages when sending instead of pushing

### DIFF
--- a/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
+++ b/backend/src/main/java/com/sim_backend/rest/controllers/MessageController.java
@@ -85,7 +85,7 @@ public class MessageController extends ControllerBase {
     Charger charger = getChargerID(ctx);
     if (charger == null) return;
     if (!checkWsClient(charger, ctx)) return;
-    Authorize msg = new Authorize();
+    Authorize msg = new Authorize(charger.getConfig().getIdTag());
 
     charger.getWsClient().pushMessage(msg);
     ctx.result("OK");

--- a/backend/src/main/java/com/sim_backend/websockets/MessageQueue.java
+++ b/backend/src/main/java/com/sim_backend/websockets/MessageQueue.java
@@ -119,6 +119,7 @@ public class MessageQueue {
 
       try {
         message.sendMessage(client);
+        client.recordTxMessage(message.toJsonString());
         queueSet.remove(message);
       } catch (WebsocketNotConnectedException ex) {
         if (message.incrementTries() >= MAX_REATTEMPTS) {

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -655,8 +655,6 @@ public class OCPPWebSocketClient extends WebSocketClient {
                       listener -> {
                         listener.onPush(new OnPushOCPPMessage(message, this));
                       }));
-
-      recordTxMessage(message.toJsonString()); // Record transmitted message
     }
     return success;
   }
@@ -667,12 +665,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
    * @param prioMessage the message to be sent.
    */
   public boolean pushPriorityMessage(final OCPPMessage prioMessage) {
-    boolean success = queue.pushPriorityMessage(prioMessage);
-    if (success) {
-      recordTxMessage(prioMessage.toJsonString());
-    }
-
-    return success;
+    return queue.pushPriorityMessage(prioMessage);
   }
 
   /**

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -343,8 +343,6 @@ public class OCPPWebSocketClient extends WebSocketClient {
       switch (callId) {
         case OCPPMessage.CALL_ID_REQUEST -> {
           results = this.parseOCPPRequest(json, msgId, array);
-          String messageName = array.get(NAME_INDEX).getAsString();
-          rxRequestNames.put(msgId, messageName);
         }
         case OCPPMessage.CALL_ID_RESPONSE -> results = this.parseOCPPResponse(json, msgId, array);
         case OCPPMessage.CALL_ID_ERROR -> {
@@ -426,6 +424,7 @@ public class OCPPWebSocketClient extends WebSocketClient {
 
     String messageName = array.get(NAME_INDEX).getAsString();
     this.recordRxMessage(json, messageName);
+    rxRequestNames.put(msgId, messageName);
     return new ParseResults(messageName, array.get(PAYLOAD_INDEX).getAsJsonObject());
   }
 

--- a/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
+++ b/backend/src/main/java/com/sim_backend/websockets/OCPPWebSocketClient.java
@@ -163,9 +163,9 @@ public class OCPPWebSocketClient extends WebSocketClient {
       if (rxRequestName == null) {
         log.error("Failed to find the CallRequest Name for message ID: " + msgId);
         return;
-    }
-    JsonElement MsgName = new JsonPrimitive(rxRequestName);
-    JsonArray newArray = insertElementAt(array, 2, MsgName);
+      }
+      JsonElement MsgName = new JsonPrimitive(rxRequestName);
+      JsonArray newArray = insertElementAt(array, 2, MsgName);
       result = gson.toJson(newArray);
     } else {
       result = message;

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -83,10 +83,17 @@ public class OCPPWebSocketClientTest {
         .when(client)
         .send(anyString());
 
+    int initialTxMessages = client.getSentMessages().size();
+
     Heartbeat beat = new Heartbeat();
     client.pushMessage(beat);
     client.popMessage();
     verify(client, times(1)).send(anyString());
+    // Verify that the message was recorded in the transmitted messages list
+    assertEquals(
+      initialTxMessages + 1,
+      client.getSentMessages().size(),
+      "A transmitted message should be recorded");
   }
 
   @Test
@@ -95,6 +102,8 @@ public class OCPPWebSocketClientTest {
 
     Heartbeat beat = new Heartbeat();
     HeartbeatResponse beat2 = new HeartbeatResponse(new Heartbeat());
+
+    int initialTxMessages = client.getSentMessages().size();
 
     client.pushMessage(beat);
     assert client.size() == 1;
@@ -105,6 +114,11 @@ public class OCPPWebSocketClientTest {
     assert client.isEmpty();
 
     verify(client, times(2)).send(anyString());
+    // Verify that 1 message was recorded in the transmitted messages list
+    assertEquals(
+      initialTxMessages + 1,
+      client.getSentMessages().size(),
+      "A transmitted message should be recorded");
   }
 
   @Test
@@ -581,7 +595,6 @@ public class OCPPWebSocketClientTest {
     // Start the queue with a single message
     client.pushMessage(new BootNotification());
 
-    int initialTxMessages = client.getSentMessages().size();
     Heartbeat heartbeat = new Heartbeat();
 
     // Push a priority message; should return true
@@ -597,12 +610,6 @@ public class OCPPWebSocketClientTest {
     assertTrue(
         client.queue.getQueueSet().contains(heartbeat),
         "Queue set should contain the pushed message");
-
-    // Verify that the message was recorded in the transmitted messages list
-    assertEquals(
-        initialTxMessages + 1,
-        client.getSentMessages().size(),
-        "A transmitted message should be recorded");
   }
 
   @Test

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -781,26 +781,26 @@ public class OCPPWebSocketClientTest {
 
   @Test
   public void testRecordTxMessageWithStoredRequestName() throws Exception {
-      String message = "[3,\"63301\",{\"status\":\"Accepted\"}]";
-  
-      // Simulate previously storing a request name for this message ID
-      client.rxRequestNames.put("63301", "GetConfiguration");
-  
-      client.recordTxMessage(message);
-  
-      assertEquals(1, client.getSentMessages().size());
-      String recordedMessage = client.getSentMessages().get(0);
-      assertTrue(recordedMessage.contains("GetConfiguration"));
-      assertTrue(recordedMessage.contains("status"));
+    String message = "[3,\"63301\",{\"status\":\"Accepted\"}]";
+
+    // Simulate previously storing a request name for this message ID
+    client.rxRequestNames.put("63301", "GetConfiguration");
+
+    client.recordTxMessage(message);
+
+    assertEquals(1, client.getSentMessages().size());
+    String recordedMessage = client.getSentMessages().get(0);
+    assertTrue(recordedMessage.contains("GetConfiguration"));
+    assertTrue(recordedMessage.contains("status"));
   }
-  
+
   @Test
   public void testRecordTxMessageWithoutStoredRequestName() {
-      String message = "[3,\"unknown_id\",{\"status\":\"Accepted\"}]";
-  
-      client.recordTxMessage(message);
-  
-      assertEquals(0, client.getSentMessages().size());
+    String message = "[3,\"unknown_id\",{\"status\":\"Accepted\"}]";
+
+    client.recordTxMessage(message);
+
+    assertEquals(0, client.getSentMessages().size());
   }
 
   @Test

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -780,23 +780,27 @@ public class OCPPWebSocketClientTest {
   }
 
   @Test
-  public void testrecordTxMessage() throws Exception {
-    String message =
-        "[3,\"633428f1-5b68-4a44-8a43-a7fee463be62\",{\"configurationKey\":[{\"key\":\"MeterValueSampleInterval\",\"value\":\"30\",\"readonly\":false}],\"unknownKey\":[]}]";
-    client.rxRequestName = "GetConfiguration";
-    client.recordTxMessage(message);
-    assertTrue(client.getSentMessages().get(0).contains("GetConfiguration"));
-    assertTrue(client.getSentMessages().get(0).contains("configurationKey"));
-    assertEquals(1, client.getSentMessages().size());
+  public void testRecordTxMessageWithStoredRequestName() throws Exception {
+      String message = "[3,\"63301\",{\"status\":\"Accepted\"}]";
+  
+      // Simulate previously storing a request name for this message ID
+      client.rxRequestNames.put("63301", "GetConfiguration");
+  
+      client.recordTxMessage(message);
+  
+      assertEquals(1, client.getSentMessages().size());
+      String recordedMessage = client.getSentMessages().get(0);
+      assertTrue(recordedMessage.contains("GetConfiguration"));
+      assertTrue(recordedMessage.contains("status"));
   }
-
+  
   @Test
-  public void testrecordTxMessage_rxRequestName_null() throws Exception {
-    String message =
-        "[3,\"633428f1-5b68-4a44-8a43-a7fee463be62\",{\"configurationKey\":[{\"key\":\"MeterValueSampleInterval\",\"value\":\"30\",\"readonly\":false}],\"unknownKey\":[]}]";
-    client.rxRequestName = null;
-    client.recordTxMessage(message);
-    assertEquals(0, client.getSentMessages().size());
+  public void testRecordTxMessageWithoutStoredRequestName() {
+      String message = "[3,\"unknown_id\",{\"status\":\"Accepted\"}]";
+  
+      client.recordTxMessage(message);
+  
+      assertEquals(0, client.getSentMessages().size());
   }
 
   @Test

--- a/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/OCPPWebSocketClientTest.java
@@ -91,9 +91,9 @@ public class OCPPWebSocketClientTest {
     verify(client, times(1)).send(anyString());
     // Verify that the message was recorded in the transmitted messages list
     assertEquals(
-      initialTxMessages + 1,
-      client.getSentMessages().size(),
-      "A transmitted message should be recorded");
+        initialTxMessages + 1,
+        client.getSentMessages().size(),
+        "A transmitted message should be recorded");
   }
 
   @Test
@@ -116,9 +116,9 @@ public class OCPPWebSocketClientTest {
     verify(client, times(2)).send(anyString());
     // Verify that 1 message was recorded in the transmitted messages list
     assertEquals(
-      initialTxMessages + 1,
-      client.getSentMessages().size(),
-      "A transmitted message should be recorded");
+        initialTxMessages + 1,
+        client.getSentMessages().size(),
+        "A transmitted message should be recorded");
   }
 
   @Test


### PR DESCRIPTION
Previously, messages would show in the "Sent Messages" log even when the simulator was offline.