### PR TITLE
Charging fixes

### DIFF
--- a/backend/src/main/java/com/sim_backend/electrical/ChargingProfileHandler.java
+++ b/backend/src/main/java/com/sim_backend/electrical/ChargingProfileHandler.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 /* TODO: This class is a work in progress. The following is what is missing.
 
 Profile Kind Handling
-- The OCPP 1.6 spec defines a chargingProfileKind (Absolute, Recurring, or 
+- The OCPP 1.6 spec defines a chargingProfileKind (Absolute, Recurring, or
 Relative) that determines how the schedule is interpreted. This implementation
 does not distinguish between these kinds or implement logic to handle recurring
 or relative profiles.

--- a/backend/src/main/java/com/sim_backend/electrical/ChargingProfileHandler.java
+++ b/backend/src/main/java/com/sim_backend/electrical/ChargingProfileHandler.java
@@ -13,6 +13,45 @@ import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 
+/* TODO: This class is a work in progress. The following is what is missing.
+
+Profile Kind Handling
+- The OCPP 1.6 spec defines a chargingProfileKind (Absolute, Recurring, or 
+Relative) that determines how the schedule is interpreted. This implementation
+does not distinguish between these kinds or implement logic to handle recurring
+or relative profiles.
+
+Recurring Charging Profiles
+- There is no support for recurring profiles (e.g. daily or weekly recurrences).
+The implementation only considers one‐off validFrom/validTo time windows and
+does not support the recurring logic defined in the standard.
+
+Connectors
+- In OCPP 1.6, a charging profile may apply to a specific connector (or even
+to all connectors). The current implementation does not account for a
+connectorId or any filtering based on which connector a profile should control.
+
+Charging Profile ID's
+- Charging profile Id uniqueness is not enforced.
+
+Profile Removal
+- The only profile management is via adding new profiles. There is no facility
+for removing an existing charging profile as required by OCPP.
+
+Validation and Ordering of Schedule Periods
+- The implementation assumes that the list of chargingSchedulePeriod entries
+is already ordered and contiguous. It does not enforce or validate that the
+schedule periods cover the intended time span without gaps or conflicts.
+
+Additional Schedule Parameters
+- Some optional fields such as minChargingRate are not handled.
+
+Error Handling and Profile Maintenance
+- Some fields defined by OCPP (like chargingProfileId, transactionId in
+non‐TX_PROFILE contexts, and proper handling of validFrom/validTo) are either
+assumed to be correct or not fully verified.
+- TxProfiles are not removed after a transaction is ended.
+*/
 @Getter
 public class ChargingProfileHandler {
   TransactionHandler transactionHandler;
@@ -148,11 +187,11 @@ public class ChargingProfileHandler {
       for (int j = 0; j < schedule.getChargingSchedulePeriod().size(); j++) {
         long startPeriod =
             schedule.getChargingSchedulePeriod().get(j).getStartPeriod() * 1000L + startReference;
-        if (startReference + startPeriod < convertedTime) {
+        if (startPeriod < convertedTime) {
           limit = schedule.getChargingSchedulePeriod().get(j).getLimit();
         }
 
-        if (startReference + startPeriod > convertedTime) {
+        if (startPeriod > convertedTime) {
           break;
         }
       }

--- a/backend/src/main/java/com/sim_backend/websockets/enums/ChargingProfileKind.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/ChargingProfileKind.java
@@ -1,5 +1,6 @@
 package com.sim_backend.websockets.enums;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,8 +8,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ChargingProfileKind {
+  @SerializedName("Absolute")
   ABSOLUTE("Absolute"),
+
+  @SerializedName("Recurring")
   RECURRING("Recurring"),
+
+  @SerializedName("Relative")
   RELATIVE("Relative");
 
   private final String value;

--- a/backend/src/main/java/com/sim_backend/websockets/enums/ChargingProfilePurpose.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/ChargingProfilePurpose.java
@@ -1,5 +1,6 @@
 package com.sim_backend.websockets.enums;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,8 +8,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ChargingProfilePurpose {
+  @SerializedName("ChargePointMaxProfile")
   CHARGE_POINT_MAX_PROFILE("ChargePointMaxProfile"),
+
+  @SerializedName("TxDefaultProfile")
   TX_DEFAULT_PROFILE("TxDefaultProfile"),
+
+  @SerializedName("TxProfile")
   TX_PROFILE("TxProfile");
 
   private final String value;

--- a/backend/src/main/java/com/sim_backend/websockets/enums/ChargingRateUnit.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/ChargingRateUnit.java
@@ -1,5 +1,6 @@
 package com.sim_backend.websockets.enums;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,9 +10,11 @@ import lombok.RequiredArgsConstructor;
 public enum ChargingRateUnit {
 
   /** Unit for amperes (A). */
+  @SerializedName("A")
   AMPS("A"),
 
   /** Unit for watts (W). */
+  @SerializedName("W")
   WATTS("W");
 
   // String value associated with each enum constant

--- a/backend/src/main/java/com/sim_backend/websockets/enums/RecurrencyKind.java
+++ b/backend/src/main/java/com/sim_backend/websockets/enums/RecurrencyKind.java
@@ -1,5 +1,6 @@
 package com.sim_backend.websockets.enums;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,9 +10,11 @@ import lombok.RequiredArgsConstructor;
 public enum RecurrencyKind {
 
   /** Daily recurrency type. */
+  @SerializedName("Daily")
   DAILY("Daily"),
 
   /** Weekly recurrency type. */
+  @SerializedName("Weekly")
   WEEKLY("Weekly");
 
   // String value associated with each enum constant

--- a/backend/src/main/java/com/sim_backend/websockets/observers/MeterValuesObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/MeterValuesObserver.java
@@ -134,7 +134,7 @@ public class MeterValuesObserver implements StateObserver {
     if (newState == ChargerState.Charging) {
       meterTask =
           scheduler.periodicFunctionJob(
-              30,
+              interval,
               interval,
               TimeUnit.SECONDS,
               () -> sendMeterValues(ReadingContext.SAMPLE_PERIODIC));

--- a/backend/src/main/java/com/sim_backend/websockets/observers/SetChargingProfileObserver.java
+++ b/backend/src/main/java/com/sim_backend/websockets/observers/SetChargingProfileObserver.java
@@ -22,6 +22,7 @@ public class SetChargingProfileObserver implements OnOCPPMessageListener {
     this.electricalTransition = electricalTransition;
     electricalTransition.setChargingProfileHandler(chargingProfileHandler);
     this.client = client;
+    this.client.onReceiveMessage(SetChargingProfile.class, this);
   }
 
   /**

--- a/backend/src/test/java/com/sim_backend/electrical/ElectricalTransitionTest.java
+++ b/backend/src/test/java/com/sim_backend/electrical/ElectricalTransitionTest.java
@@ -3,23 +3,45 @@ package com.sim_backend.electrical;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.sim_backend.charger.Charger;
 import com.sim_backend.state.ChargerState;
 import com.sim_backend.state.ChargerStateMachine;
 import com.sim_backend.transactions.TransactionHandler;
+import com.sim_backend.websockets.MessageScheduler;
+import com.sim_backend.websockets.OCPPTime;
 import com.sim_backend.websockets.OCPPWebSocketClient;
+import com.sim_backend.websockets.OCPPWebSocketClientTest.TestOCPPWebSocketClient;
 import com.sim_backend.websockets.observers.StatusNotificationObserver;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ElectricalTransitionTest {
 
+  private TestOCPPWebSocketClient mockClient;
+  private MessageScheduler mockScheduler;
+  private OCPPTime mockTime;
+
+  @BeforeEach
+  public void setUp() {
+    mockClient = mock(TestOCPPWebSocketClient.class);
+    mockScheduler = mock(MessageScheduler.class);
+    mockTime = mock(OCPPTime.class);
+
+    when(mockClient.getScheduler()).thenReturn(mockScheduler);
+    when(mockScheduler.getTime()).thenReturn(mockTime);
+    when(mockTime.getSynchronizedTime()).thenReturn(ZonedDateTime.now());
+  }
+
   @Test
   public void InitializedTest() {
 
-    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine());
+    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine(), mockClient);
     TransactionHandler handler = null;
     OCPPWebSocketClient client = null;
     try {
@@ -45,7 +67,7 @@ public class ElectricalTransitionTest {
   @Test
   public void ChargingStateTest() {
 
-    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine());
+    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine(), mockClient);
     TransactionHandler handler = null;
     OCPPWebSocketClient client = null;
     try {
@@ -75,7 +97,7 @@ public class ElectricalTransitionTest {
 
   @Test
   public void ChargingStateIntoNonCharging() {
-    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine());
+    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine(), mockClient);
     TransactionHandler handler = null;
     OCPPWebSocketClient client = null;
     try {
@@ -108,7 +130,7 @@ public class ElectricalTransitionTest {
   @Test
   public void EnergyConsumptionTest() throws InterruptedException {
     final long SECONDS_PER_HOUR = 3600;
-    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine());
+    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine(), mockClient);
     TransactionHandler handler = null;
     OCPPWebSocketClient client = null;
     try {
@@ -125,8 +147,8 @@ public class ElectricalTransitionTest {
     assertEquals(et.getEnergyActiveImportRegister(), 0);
     // Start charging.
     et.onStateChanged(ChargerState.Charging);
-    // Wait for 2 seconds to simulate a brief charging period.
-    Thread.sleep(2000);
+    // Simulate a brief charging period.
+    when(mockTime.getSynchronizedTime()).thenReturn(ZonedDateTime.now().plusSeconds(2));
     // Verify the interval energy matches the expected value.
     float intervalEnergy = et.getEnergyActiveImportInterval(100);
     float expectedEnergy = et.getPowerActiveImport() * (2.0f / SECONDS_PER_HOUR);
@@ -151,7 +173,7 @@ public class ElectricalTransitionTest {
   /** Test that multiple charging sessions correctly accumulate lifetime energy. */
   @Test
   public void testMultipleChargingSessions() throws InterruptedException {
-    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine());
+    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine(), mockClient);
     TransactionHandler handler = null;
     OCPPWebSocketClient client = null;
     try {
@@ -164,11 +186,13 @@ public class ElectricalTransitionTest {
     et.setChargingProfileHandler(new ChargingProfileHandler(handler, client));
 
     et.onStateChanged(ChargerState.Charging);
-    Thread.sleep(1000); // Simulate 1 second of charging.
+    when(mockTime.getSynchronizedTime())
+        .thenReturn(ZonedDateTime.now().plusSeconds(1)); // Simulate 1 second of charging.
     et.onStateChanged(ChargerState.PoweredOff);
     float energyAfterSession1 = et.getEnergyActiveImportRegister();
     et.onStateChanged(ChargerState.Charging);
-    Thread.sleep(1000); // Simulate 1 second of charging.
+    when(mockTime.getSynchronizedTime())
+        .thenReturn(ZonedDateTime.now().plusSeconds(2)); // Simulate 1 more second of charging.
     et.onStateChanged(ChargerState.PoweredOff);
     float energyAfterSession2 = et.getEnergyActiveImportRegister();
     // Lifetime energy should increase over sessions.
@@ -182,7 +206,7 @@ public class ElectricalTransitionTest {
    */
   @Test
   public void testGetEnergyActiveImportIntervalNegativeInterval() throws InterruptedException {
-    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine());
+    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine(), mockClient);
     TransactionHandler handler = null;
     OCPPWebSocketClient client = null;
     try {
@@ -204,7 +228,7 @@ public class ElectricalTransitionTest {
   /** Test that a zero interval returns zero energy consumption. */
   @Test
   public void testZeroInterval() {
-    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine());
+    ElectricalTransition et = new ElectricalTransition(new ChargerStateMachine(), mockClient);
     TransactionHandler handler = null;
     OCPPWebSocketClient client = null;
     try {

--- a/backend/src/test/java/com/sim_backend/websockets/observers/MeterValuesObserverTest.java
+++ b/backend/src/test/java/com/sim_backend/websockets/observers/MeterValuesObserverTest.java
@@ -145,13 +145,13 @@ public class MeterValuesObserverTest {
     when(config.getMeterValueSampleInterval()).thenReturn(10);
     // Create a dummy repeating task to simulate scheduling
     RepeatingTimedTask dummyTask = mock(RepeatingTimedTask.class);
-    when(scheduler.periodicFunctionJob(eq(30L), eq(10L), eq(TimeUnit.SECONDS), any()))
+    when(scheduler.periodicFunctionJob(eq(10L), eq(10L), eq(TimeUnit.SECONDS), any()))
         .thenReturn(dummyTask);
 
     observer.onStateChanged(ChargerState.Charging);
 
     // Verify that a periodic job was scheduled
-    verify(scheduler).periodicFunctionJob(eq(30L), eq(10L), eq(TimeUnit.SECONDS), any());
+    verify(scheduler).periodicFunctionJob(eq(10L), eq(10L), eq(TimeUnit.SECONDS), any());
   }
 
   @Test
@@ -159,7 +159,7 @@ public class MeterValuesObserverTest {
     when(config.getMeterValueSampleInterval()).thenReturn(10);
     // Create a dummy repeating task
     RepeatingTimedTask dummyTask = mock(RepeatingTimedTask.class);
-    when(scheduler.periodicFunctionJob(eq(30L), eq(10L), eq(TimeUnit.SECONDS), any()))
+    when(scheduler.periodicFunctionJob(eq(10L), eq(10L), eq(TimeUnit.SECONDS), any()))
         .thenReturn(dummyTask);
 
     // Transition to Charging to schedule the task.


### PR DESCRIPTION
Charging timestamps were based on realtime, not simulator time. This resulted in charging profiles not taking effect if the simulator time was behind realtime.